### PR TITLE
feat: update rand and stop relying on thread_rng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,13 +180,14 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -325,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
@@ -404,20 +411,20 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
+ "zerocopy",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -425,18 +432,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_distr"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand",
@@ -556,18 +563,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,9 +609,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -751,3 +761,32 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09612fda0b63f7cb9e0af7e5916fe5a1f8cdcb066829f10f36883207628a4872"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79f81d38d7a2ed52d8f034e62c568e111df9bf8aba2f7cf19ddc5bf7bd89d520"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,22 +8,32 @@ homepage = "https://docs.rs/little_sorry"
 repository = "https://github.com/elliottneilclark/little-sorry"
 description = "Library to help with coding regret minimization."
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 
 
 [dependencies]
 ndarray = "~0.16.1"
-rand = "~0.8.5"
-rand_distr = "~0.4.3"
-once_cell = "~1"
+rand = "~0.9.0"
+rand_distr = "~0.5.1"
 thiserror = "~2"
+once_cell = { version = "~1.20.3", optional = true }
+
+[features]
+default = []
+rps = ["dep:once_cell"]
 
 [dev-dependencies]
 criterion = "0.5.1"
 
+[[bin]]
+required-features = ["rps"]
+name = "run_rps"
+path = "src/bin/run_rps.rs"
+
 [[bench]]
 name = "rps"
 harness = false
+required-features = ["rps"]
 
 [profile.release]
 debug = true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Little Sorry
+
+A Rust library for exploring regret minimization algorithms, with a focus on game theory applications.
+
+## Features
+
+- Regret matching implementation
+- Rock Paper Scissors (RPS) example game
+- Highly performant using ndarray for numerical operations
+- Thread-safe with no unsafe code (except for carefully bounded enum conversions)
+
+## Getting Started
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+little-sorry = "0.5.0"
+```
+
+## How It Works
+
+The library implements regret minimization algorithms, which are used in game theory to find optimal strategies in imperfect-information games. The core algorithm tracks:
+
+1. Action probabilities for each possible move
+2. Cumulative regret for not taking alternative actions
+3. Strategy updates based on regret matching
+
+The RPS example demonstrates these concepts in a simple zero-sum game setting.
+
+## Building and Testing
+
+```bash
+# Run all tests
+cargo test
+
+# Run benchmarks
+cargo bench
+
+# Build in release mode
+cargo build --release
+```
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/benches/rps.rs
+++ b/benches/rps.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use std::time::Instant;
 
@@ -8,9 +8,10 @@ pub fn bench(c: &mut Criterion) {
     c.bench_function("iter", move |b| {
         b.iter_custom(|iters| {
             let mut runner = RPSRunner::new().unwrap();
+            let mut rng = rand::rng();
             let start = Instant::now();
             for _i in 0..iters {
-                runner.run_one();
+                runner.run_one(&mut rng);
                 runner.update_regret().unwrap();
             }
             start.elapsed()

--- a/src/bin/run_rps.rs
+++ b/src/bin/run_rps.rs
@@ -8,8 +8,9 @@ static NUM_ITERS: usize = 100_000_000;
 fn main() {
     let mut runner = RPSRunner::new().unwrap();
     dbg!(&runner.matcher_one);
+    let mut rng = rand::rng();
     for i in 0..NUM_ITERS {
-        runner.run_one();
+        runner.run_one(&mut rng);
 
         if i % 50 == 0 || i == NUM_ITERS - 1 {
             runner.update_regret().unwrap();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use rand_distr::WeightedError;
+use rand_distr::weighted::Error as WeightedError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 pub mod errors;
 pub mod regret_matcher;
+
+#[cfg(feature = "rps")]
 pub mod rps;
 
 pub use self::regret_matcher::RegretMatcher;

--- a/src/rps.rs
+++ b/src/rps.rs
@@ -7,12 +7,18 @@ use std::mem;
 
 use std::vec::Vec;
 
+/// Represents the actions in Rock-Paper-Scissors game.
+///
+/// This uses unsafe code to do the conversion so it shows as dead code.
 #[allow(dead_code)]
 #[repr(usize)]
 #[derive(Debug, Clone, Copy)]
 enum RPSAction {
+    /// Rock action.
     Rock = 0,
+    /// Paper action.
     Paper = 1,
+    /// Scissors action.
     Scissors = 2,
 }
 
@@ -21,6 +27,11 @@ static PAPER_REWARD: Lazy<Array1<f32>> = Lazy::new(|| array![-1.0_f32, 0.0_f32, 
 static SCISSOR_REWARD: Lazy<Array1<f32>> = Lazy::new(|| array![1.0_f32, -1.0_f32, 0.0_f32]);
 
 impl RPSAction {
+    /// Converts the action to its corresponding reward array view.
+    ///
+    /// # Returns
+    ///
+    /// An array view of rewards for the action.
     pub fn to_reward(self) -> ArrayView1<'static, f32> {
         match self {
             Self::Rock => ROCK_REWARD.view(),
@@ -31,6 +42,15 @@ impl RPSAction {
 }
 
 impl From<usize> for RPSAction {
+    /// Converts a usize to an RPSAction.
+    ///
+    /// # Arguments
+    ///
+    /// * `i` - The usize value to convert.
+    ///
+    /// # Safety
+    ///
+    /// This function uses `unsafe` to transmute the usize value to an RPSAction.
     fn from(i: usize) -> Self {
         unsafe {
             mem::transmute(cmp::max(
@@ -41,22 +61,30 @@ impl From<usize> for RPSAction {
     }
 }
 
+/// Runner for the Rock-Paper-Scissors game using regret matching.
 #[derive(Debug, Clone)]
 pub struct RPSRunner {
+    /// Regret matcher for the first player.
     pub matcher_one: RegretMatcher,
+    /// Regret matcher for the second player.
     pub matcher_two: RegretMatcher,
     pending_reward_one: Array1<f32>,
     pending_reward_two: Array1<f32>,
 }
 
 impl Default for RPSRunner {
-    #[must_use]
+    /// Creates a new `RPSRunner` with default values.
     fn default() -> Self {
         Self::new().unwrap()
     }
 }
 
 impl RPSRunner {
+    /// Creates a new `RPSRunner`.
+    ///
+    /// # Returns
+    ///
+    /// A result containing the new `RPSRunner` or a `LittleError`.
     pub fn new() -> Result<Self, LittleError> {
         Ok(Self {
             matcher_one: RegretMatcher::new(3)?,
@@ -65,13 +93,25 @@ impl RPSRunner {
             pending_reward_two: Array1::zeros(3),
         })
     }
-    pub fn run_one(&mut self) {
-        let a1 = RPSAction::from(self.matcher_one.next_action());
-        let a2 = RPSAction::from(self.matcher_two.next_action());
+
+    /// Runs one iteration of the Rock-Paper-Scissors game.
+    ///
+    /// # Arguments
+    ///
+    /// * `rng` - A mutable reference to a random number generator.
+    pub fn run_one<R: rand::Rng>(&mut self, rng: &mut R) {
+        let a1 = RPSAction::from(self.matcher_one.next_action(rng));
+        let a2 = RPSAction::from(self.matcher_two.next_action(rng));
 
         self.pending_reward_one += &a2.to_reward();
         self.pending_reward_two += &a1.to_reward();
     }
+
+    /// Updates the regret values for both players.
+    ///
+    /// # Returns
+    ///
+    /// A result indicating success or a `LittleError`.
     pub fn update_regret(&mut self) -> Result<(), LittleError> {
         self.matcher_one
             .update_regret(self.pending_reward_one.view())?;
@@ -82,8 +122,40 @@ impl RPSRunner {
         self.pending_reward_two.fill(0.0);
         Ok(())
     }
+
+    /// Returns the best weight for the first player.
+    ///
+    /// # Returns
+    ///
+    /// A vector of floats representing the best weight.
     #[must_use]
     pub fn best_weight(&self) -> Vec<f32> {
         self.matcher_one.best_weight()
+    }
+
+    /// Returns the best weight for the second player.
+    ///
+    /// # Returns
+    ///
+    /// A vector of floats representing the best weight for the opponent player.
+    pub fn opponent_best_weight(&self) -> Vec<f32> {
+        self.matcher_two.best_weight()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests the Rock-Paper-Scissors runner.
+    #[test]
+    fn test_rps() {
+        let mut runner = RPSRunner::new().unwrap();
+        let mut rng = rand::rng();
+        for _ in 0..100 {
+            runner.run_one(&mut rng);
+            runner.update_regret().unwrap();
+        }
+        dbg!(runner.best_weight());
     }
 }


### PR DESCRIPTION
Summary:
Now we can have the user pass in their own rng. This also allows
deterministic usage.

While updating. I added the rps feature. It is not on by deault. Since
that also is the only place the once_cell is used, we drop that
dependecy by default.

Test Plan:
cargo test
