### PR TITLE
feat(matchers): batched storage-generic CFR matchers + export codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ A Rust library for regret minimization algorithms (Counterfactual Regret Minimiz
 - Zero-allocation hot path — no heap allocations during `update_regret`
 - Minimal dependencies (`rand` only)
 - Rock-Paper-Scissors example game (feature-gated behind `rps`)
+- **Batched, storage-generic matchers** for large and concurrent solves —
+  `BatchedMatcher<Rule, Backend>` owns many information sets on one shared
+  iteration clock, generic over the update rule and over a single-threaded or
+  lock-free atomic cell backend
+- **Compact strategy export** — dependency-free fixed-point quantization of a
+  solved average strategy (`quantize_dist` / `dequantize_dist`)
 
 ## Getting Started
 
@@ -52,6 +58,38 @@ fn train<M: RegretMinimizer>(matcher: &mut M, iterations: usize) {
         matcher.update_regret(rewards);
     }
 }
+```
+
+### Scaling up: batched matchers and strategy export
+
+For abstraction-based or multi-threaded solvers, `BatchedMatcher` owns many
+information sets ("rows") that advance together, so per-iteration discount
+factors are computed once per visit instead of once per row. The update rule and
+the storage backend are each one type parameter: pick `Local` for a
+zero-overhead single-threaded solve or `Atomic` to update a shared matcher
+lock-free from many threads. The solved average strategy reads out identically
+for every rule and can be exported to compact fixed-point codes.
+
+```rust
+use little_sorry::{BatchedMatcher, Dcfr, DiscountParams, Local};
+use little_sorry::{dequantize_dist, quantize_dist};
+
+// One node owning 8 abstraction classes over 3 actions, using DCFR on the
+// single-threaded backend. Swap `Dcfr` for `PdcfrPlus`, or `Local` for
+// `Atomic`, with no other changes.
+let node = BatchedMatcher::<Dcfr, Local>::new(8, 3, DiscountParams::RECOMMENDED);
+
+let mut expected = [0.0; 8];
+for _ in 0..1000 {
+    node.update_batch(|action, _row| [1.0, -0.5, 0.2][action], &mut expected);
+}
+
+// Export row 0's average strategy compactly, then reload it.
+let mut probs = [0.0; 3];
+node.average_into(0, &mut probs);
+let codes: Vec<u16> = quantize_dist(&probs);
+let reloaded = dequantize_dist::<u16>(&codes); // decodes and renormalizes
+assert!((reloaded.iter().sum::<f32>() - 1.0).abs() < 1e-6);
 ```
 
 ## Building and Testing

--- a/src/batched_matcher.rs
+++ b/src/batched_matcher.rs
@@ -1,0 +1,490 @@
+//! A matcher owning many information sets over a pluggable cell backend.
+//!
+//! One instance holds `num_rows` information sets ("rows"), each over the same
+//! `num_actions`, laid out as a single flat array of cells addressed
+//! `[row][lane][action]` (lanes per [`crate::update_rule`]). All rows share one
+//! iteration clock: a single batched update advances the clock once and touches
+//! every row, so the time-dependent factors a rule needs are computed once for
+//! the whole batch rather than once per row — the win that makes a decision
+//! point owning hundreds of rows cheap.
+//!
+//! Updates run entirely through `&self` via the backend's interior-mutable
+//! cells, and touch each cell with an independent load/store, so the same code
+//! drives the single-threaded [`crate::storage::Local`] backend and the
+//! lock-free [`crate::storage::Atomic`] one. With `Local` the matcher is `!Sync`
+//! and fully deterministic; with `Atomic` it is `Sync` and may be updated
+//! concurrently, with the benign-race semantics documented on the backend.
+//!
+//! The current strategy is never stored — it is re-derived from the lanes on
+//! demand. That drops a whole per-row array, and re-deriving it from unchanged
+//! regret reproduces exactly the strategy a stored-strategy matcher would carry,
+//! which is what makes a batch-size-1 matcher match its scalar counterpart
+//! bit-for-bit.
+
+use crate::storage::{CounterCell, FloatCell, StorageBackend};
+use crate::update_rule::UpdateRule;
+use std::marker::PhantomData;
+
+/// Per-call working buffers, sized to one row. Allocated once per update call
+/// and reused across every row in a batch, so the per-row hot path allocates
+/// nothing.
+struct Scratch {
+    regret: Vec<f32>,
+    last_inst: Vec<f32>,
+    strategy: Vec<f32>,
+    reward: Vec<f32>,
+}
+
+impl Scratch {
+    fn new(num_actions: usize) -> Self {
+        Self {
+            regret: vec![0.0; num_actions],
+            last_inst: vec![0.0; num_actions],
+            strategy: vec![0.0; num_actions],
+            reward: vec![0.0; num_actions],
+        }
+    }
+}
+
+/// A batched regret matcher generic over the update rule `R` and the storage
+/// backend `B`.
+pub struct BatchedMatcher<R: UpdateRule, B: StorageBackend> {
+    params: R::Params,
+    num_rows: usize,
+    num_actions: usize,
+    row_stride: usize,
+    cells: Vec<B::Float>,
+    counter: B::Counter,
+    /// Shared regret-weight accumulator for the average-regret diagnostic; one
+    /// scalar for the whole batch, advanced once per tick.
+    regret_weight: B::Float,
+    _rule: PhantomData<R>,
+}
+
+impl<R: UpdateRule, B: StorageBackend> BatchedMatcher<R, B> {
+    /// Lane indices. Lane 0 holds cumulative regret, lane 1 cumulative strategy,
+    /// and (predictive rules) lane 2 the last instantaneous regret.
+    const REGRET: usize = 0;
+    const STRATEGY: usize = 1;
+    const LAST_INST: usize = 2;
+
+    /// Create a matcher of `num_rows` information sets over `num_actions`
+    /// actions. All accumulators start at zero, so every row reads as the
+    /// uniform strategy until updated.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_rows` or `num_actions` is zero.
+    #[must_use]
+    pub fn new(num_rows: usize, num_actions: usize, params: R::Params) -> Self {
+        assert!(num_rows > 0, "num_rows must be > 0");
+        assert!(num_actions > 0, "num_actions must be > 0");
+        let row_stride = R::LANES * num_actions;
+        let cells = (0..num_rows * row_stride)
+            .map(|_| B::Float::default())
+            .collect();
+        Self {
+            params,
+            num_rows,
+            num_actions,
+            row_stride,
+            cells,
+            counter: B::Counter::default(),
+            regret_weight: B::Float::default(),
+            _rule: PhantomData,
+        }
+    }
+
+    /// Number of information sets.
+    #[must_use]
+    pub fn num_rows(&self) -> usize {
+        self.num_rows
+    }
+
+    /// Number of actions per information set.
+    #[must_use]
+    pub fn num_actions(&self) -> usize {
+        self.num_actions
+    }
+
+    /// Number of updates (clock ticks) applied so far.
+    #[must_use]
+    pub fn num_updates(&self) -> usize {
+        self.counter.load()
+    }
+
+    #[inline]
+    fn cell(&self, row: usize, lane: usize, action: usize) -> &B::Float {
+        &self.cells[row * self.row_stride + lane * self.num_actions + action]
+    }
+
+    /// Advance the shared clock by one tick and compute the rule's per-iteration
+    /// constants once for the resulting iteration.
+    fn tick(&self) -> R::Step {
+        let t = self.counter.fetch_incr() + 1;
+        R::step(&self.params, t)
+    }
+
+    /// Apply this tick's regret-weight recurrence to the shared accumulator.
+    fn advance_weight(&self, step: &R::Step) {
+        self.regret_weight
+            .store(R::regret_weight_step(step, self.regret_weight.load()));
+    }
+
+    /// Update one row against a precomputed step, returning the row's expected
+    /// value under its pre-update strategy. This is the whole per-cell dance;
+    /// `tick`/`advance_weight` handle the shared clock and weight around it.
+    fn update_one(
+        &self,
+        row: usize,
+        step: &R::Step,
+        value: impl Fn(usize) -> f32,
+        s: &mut Scratch,
+    ) -> f32 {
+        let a = self.num_actions;
+        let predictive = R::LANES > Self::LAST_INST;
+
+        // Snapshot the lanes we read, and cache the rewards so the value
+        // accessor is called exactly once per action.
+        for i in 0..a {
+            s.regret[i] = self.cell(row, Self::REGRET, i).load();
+            if predictive {
+                s.last_inst[i] = self.cell(row, Self::LAST_INST, i).load();
+            }
+            s.reward[i] = value(i);
+        }
+
+        // Expected value uses the strategy carried in from the previous tick,
+        // re-derived from the unchanged lanes (predictive rules discount the
+        // regret term by the previous iterate's factor).
+        R::strategy_from_lanes(
+            &self.params,
+            &s.regret,
+            &s.last_inst,
+            R::pre_discount(step),
+            &mut s.strategy,
+        );
+        let expected = crate::vector_ops::dot(&s.strategy, &s.reward);
+
+        // Per-cell regret update; predictive rules also store the fresh
+        // instantaneous regret for next tick's prediction.
+        for i in 0..a {
+            let new_r = R::accumulate_regret(step, s.regret[i], s.reward[i], expected);
+            self.cell(row, Self::REGRET, i).store(new_r);
+            s.regret[i] = new_r;
+            if predictive {
+                let inst = s.reward[i] - expected;
+                self.cell(row, Self::LAST_INST, i).store(inst);
+                s.last_inst[i] = inst;
+            }
+        }
+
+        // The strategy this tick plays (and accumulates) is derived from the
+        // updated lanes, then folded into the cumulative-strategy lane.
+        R::strategy_from_lanes(
+            &self.params,
+            &s.regret,
+            &s.last_inst,
+            R::post_discount(step),
+            &mut s.strategy,
+        );
+        let (discount, weight) = R::strategy_accumulation(step);
+        for i in 0..a {
+            let cell = self.cell(row, Self::STRATEGY, i);
+            cell.store(cell.load() * discount + weight * s.strategy[i]);
+        }
+
+        expected
+    }
+
+    /// Advance every row by one shared tick. `value(action, row)` supplies the
+    /// reward for an action at a row from whatever layout the caller holds;
+    /// `expected_out[row]` receives that row's expected value under its
+    /// pre-update strategy (for propagating values up a game tree).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `expected_out.len() < num_rows`.
+    pub fn update_batch(&self, value: impl Fn(usize, usize) -> f32, expected_out: &mut [f32]) {
+        assert!(
+            expected_out.len() >= self.num_rows,
+            "expected_out too short"
+        );
+        let step = self.tick();
+        let mut scratch = Scratch::new(self.num_actions);
+        for (row, ev) in expected_out.iter_mut().enumerate().take(self.num_rows) {
+            *ev = self.update_one(row, &step, |a| value(a, row), &mut scratch);
+        }
+        self.advance_weight(&step);
+    }
+
+    /// Advance a single row by one shared tick, returning its expected value.
+    /// For solvers that do not visit every row each iteration; the batching win
+    /// only applies when many rows share a tick.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `row >= num_rows`.
+    pub fn update_row(&self, row: usize, value: impl Fn(usize) -> f32) -> f32 {
+        assert!(row < self.num_rows, "row out of range");
+        let step = self.tick();
+        let mut scratch = Scratch::new(self.num_actions);
+        let ev = self.update_one(row, &step, value, &mut scratch);
+        self.advance_weight(&step);
+        ev
+    }
+
+    /// Write a row's current strategy (the distribution it would play next) into
+    /// `out`. Equal to what a stored-strategy matcher would hold.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `row >= num_rows` or `out.len() < num_actions`.
+    pub fn current_into(&self, row: usize, out: &mut [f32]) {
+        assert!(row < self.num_rows, "row out of range");
+        assert!(out.len() >= self.num_actions, "out too short");
+        let out = &mut out[..self.num_actions];
+        let t = self.num_updates();
+        let step = R::step(&self.params, t);
+        let predictive = R::LANES > Self::LAST_INST;
+        let mut regret = vec![0.0; self.num_actions];
+        let mut last_inst = vec![0.0; self.num_actions];
+        for i in 0..self.num_actions {
+            regret[i] = self.cell(row, Self::REGRET, i).load();
+            if predictive {
+                last_inst[i] = self.cell(row, Self::LAST_INST, i).load();
+            }
+        }
+        R::strategy_from_lanes(
+            &self.params,
+            &regret,
+            &last_inst,
+            R::post_discount(&step),
+            out,
+        );
+    }
+
+    /// Write a row's average strategy — the normalized cumulative strategy, i.e.
+    /// the equilibrium approximation — into `out`. This is the single,
+    /// algorithm-independent readout the export codec consumes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `row >= num_rows` or `out.len() < num_actions`.
+    pub fn average_into(&self, row: usize, out: &mut [f32]) {
+        assert!(row < self.num_rows, "row out of range");
+        assert!(out.len() >= self.num_actions, "out too short");
+        let out = &mut out[..self.num_actions];
+        for (i, slot) in out.iter_mut().enumerate() {
+            *slot = self.cell(row, Self::STRATEGY, i).load();
+        }
+        crate::probability::normalize_inplace(out);
+    }
+
+    /// The average-regret convergence diagnostic for a row: the maximum positive
+    /// cumulative regret over the shared regret-weight total. Tends to zero as
+    /// the row approaches equilibrium; `0.0` before any update.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `row >= num_rows`.
+    #[must_use]
+    pub fn average_regret(&self, row: usize) -> f32 {
+        assert!(row < self.num_rows, "row out of range");
+        let w = R::regret_weight_total(&self.params, self.num_updates(), self.regret_weight.load());
+        if w <= 0.0 {
+            return 0.0;
+        }
+        let max_pos = (0..self.num_actions).fold(0.0_f32, |m, i| {
+            m.max(self.cell(row, Self::REGRET, i).load().max(0.0))
+        });
+        max_pos / w
+    }
+}
+
+#[cfg(test)]
+impl<R: UpdateRule, B: StorageBackend> BatchedMatcher<R, B> {
+    /// Raw cumulative-regret lane for a row (test-only; the public surface
+    /// exposes derived strategies, not raw accumulators).
+    fn raw_regret(&self, row: usize) -> Vec<f32> {
+        (0..self.num_actions)
+            .map(|i| self.cell(row, Self::REGRET, i).load())
+            .collect()
+    }
+
+    /// Raw cumulative-strategy lane for a row (test-only).
+    fn raw_strategy(&self, row: usize) -> Vec<f32> {
+        (0..self.num_actions)
+            .map(|i| self.cell(row, Self::STRATEGY, i).load())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discount::DiscountParams;
+    use crate::rules::{Dcfr, PdcfrPlus};
+    use crate::storage::Local;
+
+    #[test]
+    fn fresh_matcher_reads_uniform() {
+        let m = BatchedMatcher::<Dcfr, Local>::new(2, 3, DiscountParams::RECOMMENDED);
+        let mut out = [0.0f32; 3];
+        m.average_into(0, &mut out);
+        assert!(
+            out.iter().all(|&v| (v - 1.0 / 3.0).abs() < 1e-6),
+            "avg {out:?}"
+        );
+        m.current_into(1, &mut out);
+        assert!(
+            out.iter().all(|&v| (v - 1.0 / 3.0).abs() < 1e-6),
+            "cur {out:?}"
+        );
+        assert_eq!(m.num_updates(), 0);
+    }
+
+    #[test]
+    fn symmetric_reward_from_uniform_has_zero_expected_value() {
+        let m = BatchedMatcher::<Dcfr, Local>::new(1, 3, DiscountParams::RECOMMENDED);
+        let ev = m.update_row(0, |a| [1.0, -1.0, 0.0][a]);
+        assert!(ev.abs() < 1e-6, "ev {ev}");
+        assert_eq!(m.num_updates(), 1);
+    }
+
+    #[test]
+    fn update_batch_fills_expected_value_per_row() {
+        let m = BatchedMatcher::<Dcfr, Local>::new(2, 2, DiscountParams::RECOMMENDED);
+        let mut ev = [0.0f32; 2];
+        // Uniform strategy: row 0 EV = (2+0)/2 = 1; row 1 EV = (0+4)/2 = 2.
+        m.update_batch(
+            |a, row| {
+                if row == 0 {
+                    [2.0, 0.0][a]
+                } else {
+                    [0.0, 4.0][a]
+                }
+            },
+            &mut ev,
+        );
+        assert!((ev[0] - 1.0).abs() < 1e-6, "{ev:?}");
+        assert!((ev[1] - 2.0).abs() < 1e-6, "{ev:?}");
+        assert_eq!(m.num_updates(), 1); // one shared tick for the whole batch
+    }
+
+    #[test]
+    fn predictive_rule_uses_three_lanes() {
+        // A 3-lane rule must allocate and drive its extra last-instantaneous
+        // lane without panicking on the out-of-2-lane index.
+        let m = BatchedMatcher::<PdcfrPlus, Local>::new(1, 3, PdcfrPlus::RECOMMENDED);
+        let mut out = [0.0f32; 3];
+        for _ in 0..5 {
+            m.update_row(0, |a| [1.0, 0.0, -1.0][a]);
+        }
+        m.average_into(0, &mut out);
+        assert!((out.iter().sum::<f32>() - 1.0).abs() < 1e-5);
+    }
+
+    // ── Golden bit-for-bit equivalence with the scalar matchers ─────────────
+    //
+    // A batch-size-1 matcher on the Local backend must reproduce its scalar
+    // counterpart exactly — same cumulative regret, cumulative strategy, current
+    // strategy, and average strategy — over an identical reward sequence. This
+    // is the deterministic-reproducibility contract downstream solvers rely on,
+    // so the comparison is on raw bit patterns, not an approximate tolerance.
+
+    use crate::regret_minimizer::RegretMinimizer;
+    use crate::rules::{DcfrPlus, LinearCfr, PcfrPlus};
+
+    /// Deterministic reward stream in roughly `[-1, 1]`, identical for both
+    /// matchers. A plain LCG keeps the sequence reproducible without pulling in
+    /// `rand` or floating-point seeding.
+    fn next_reward(state: &mut u64) -> f32 {
+        *state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let unit = (*state >> 40) as f32 / (1u64 << 24) as f32; // [0, 1)
+        2.0 * unit - 1.0
+    }
+
+    fn assert_bits(label: &str, got: &[f32], want: &[f32]) {
+        assert_eq!(got.len(), want.len(), "{label}: length");
+        for (i, (&g, &w)) in got.iter().zip(want).enumerate() {
+            assert_eq!(g.to_bits(), w.to_bits(), "{label}[{i}]: {g} != {w}");
+        }
+    }
+
+    /// Drive a batched rule and its scalar twin over the same rewards, asserting
+    /// bit-equality of every quantity after every update.
+    fn golden<R, M>(params: R::Params, mut scalar: M, num_actions: usize, iters: usize)
+    where
+        R: UpdateRule,
+        M: RegretMinimizer,
+    {
+        let batched = BatchedMatcher::<R, Local>::new(1, num_actions, params);
+        let mut state = 0x1234_5678_9abc_def0;
+        let mut current = vec![0.0f32; num_actions];
+        for _ in 0..iters {
+            let rewards: Vec<f32> = (0..num_actions).map(|_| next_reward(&mut state)).collect();
+            scalar.update_regret(&rewards);
+            batched.update_row(0, |a| rewards[a]);
+
+            assert_bits("regret", &batched.raw_regret(0), scalar.cumulative_regret());
+            assert_bits(
+                "strategy",
+                &batched.raw_strategy(0),
+                scalar.cumulative_strategy(),
+            );
+            batched.current_into(0, &mut current);
+            assert_bits("current", &current, scalar.current_strategy());
+        }
+        let mut average = vec![0.0f32; num_actions];
+        batched.average_into(0, &mut average);
+        assert_bits("average", &average, &scalar.best_weight());
+    }
+
+    #[test]
+    fn golden_dcfr() {
+        golden::<Dcfr, _>(
+            DiscountParams::RECOMMENDED,
+            DiscountedRegretMatcher::recommended(4),
+            4,
+            200,
+        );
+    }
+
+    #[test]
+    fn golden_dcfr_plus() {
+        golden::<DcfrPlus, _>(
+            DcfrPlus::RECOMMENDED,
+            DcfrPlusRegretMatcher::recommended(4),
+            4,
+            200,
+        );
+    }
+
+    #[test]
+    fn golden_linear_cfr() {
+        golden::<LinearCfr, _>((), LinearCfrRegretMatcher::new(4), 4, 200);
+    }
+
+    #[test]
+    fn golden_pcfr_plus() {
+        golden::<PcfrPlus, _>((), PcfrPlusRegretMatcher::new(4), 4, 200);
+    }
+
+    #[test]
+    fn golden_pdcfr_plus() {
+        golden::<PdcfrPlus, _>(
+            PdcfrPlus::RECOMMENDED,
+            PdcfrPlusRegretMatcher::recommended(4),
+            4,
+            200,
+        );
+    }
+
+    use crate::{
+        DcfrPlusRegretMatcher, DiscountedRegretMatcher, LinearCfrRegretMatcher,
+        PcfrPlusRegretMatcher, PdcfrPlusRegretMatcher,
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,40 @@
 //! let strategy = matcher.best_weight();
 //! assert!((strategy.iter().sum::<f32>() - 1.0).abs() < 1e-6);
 //! ```
+//!
+//! ## Batched, storage-generic matchers
+//!
+//! For large or concurrent solves, [`BatchedMatcher`] owns many information sets
+//! ("rows") that advance on one shared iteration clock, so a rule's
+//! time-dependent factors are computed once per batch rather than once per row.
+//! It is generic over both the update rule (one of [`Dcfr`], [`DcfrPlus`],
+//! [`LinearCfr`], [`PcfrPlus`], [`PdcfrPlus`]) and the cell backend ([`Local`]
+//! for zero-overhead single-threaded use, [`Atomic`] for lock-free concurrent
+//! updates through a shared reference). Swapping either is a one-type change.
+//!
+//! The solved average strategy reads out the same way for every rule and can be
+//! exported compactly with [`quantize_dist`] / [`dequantize_dist`]:
+//!
+//! ```
+//! use little_sorry::{BatchedMatcher, Dcfr, DiscountParams, Local};
+//! use little_sorry::{dequantize_dist, quantize_dist};
+//!
+//! // One node owning 8 abstraction classes over 3 actions.
+//! let node = BatchedMatcher::<Dcfr, Local>::new(8, 3, DiscountParams::RECOMMENDED);
+//! let mut expected = [0.0; 8];
+//! for _ in 0..1000 {
+//!     // The caller supplies values from whatever layout it holds.
+//!     node.update_batch(|action, _row| [1.0, -0.5, 0.2][action], &mut expected);
+//! }
+//!
+//! let mut probs = [0.0; 3];
+//! node.average_into(0, &mut probs); // normalized average strategy, any rule
+//! let codes = quantize_dist::<u16>(&probs); // compact on-disk form
+//! let reloaded = dequantize_dist::<u16>(&codes); // decodes AND renormalizes
+//! assert!((reloaded.iter().sum::<f32>() - 1.0).abs() < 1e-6);
+//! ```
 
+pub mod batched_matcher;
 pub mod cfr_plus;
 pub mod dcfr;
 pub mod dcfr_plus;
@@ -37,7 +70,11 @@ pub mod discount;
 pub mod linear_cfr;
 pub mod pcfr_plus;
 pub mod pdcfr_plus;
+pub mod quantize;
 pub mod regret_minimizer;
+pub mod rules;
+pub mod storage;
+pub mod update_rule;
 
 mod probability;
 mod vector_ops;
@@ -53,6 +90,13 @@ pub use linear_cfr::LinearCfrRegretMatcher;
 pub use pcfr_plus::PcfrPlusRegretMatcher;
 pub use pdcfr_plus::PdcfrPlusRegretMatcher;
 pub use regret_minimizer::RegretMinimizer;
+
+// Batched, storage-generic machinery.
+pub use batched_matcher::BatchedMatcher;
+pub use quantize::{FixedWidth, dequantize_dist, quantize_dist};
+pub use rules::{Dcfr, DcfrPlus, LinearCfr, PcfrPlus, PdcfrPlus, PlusDiscount};
+pub use storage::{Atomic, Local};
+pub use update_rule::UpdateRule;
 
 // Re-export for backwards compatibility
 pub use cfr_plus::CfrPlusRegretMatcher as RegretMatcher;

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -1,0 +1,145 @@
+//! Fixed-point export codec for normalized strategies.
+//!
+//! A solved average strategy is a probability distribution: each entry sits in
+//! `[0, 1]` and the row sums to one. Shipping it as 32-bit floats wastes space
+//! when a read-only runtime only needs a few decimal digits of accuracy. A
+//! *fixed-point* code maps the unit interval onto the evenly spaced integers
+//! `0..=MAX`: a value `x` becomes the nearest integer `round(x · MAX)`, and a
+//! code `c` decodes back to `c / MAX`. With `MAX = 2^b − 1` both endpoints stay
+//! exact (`0 → 0`, `1 → MAX`), and the spacing between representable values —
+//! the *quantum* — is `1 / MAX`. For 16-bit codes that quantum is
+//! `1/65535 ≈ 1.526e-5`; round-to-nearest keeps each component within half a
+//! quantum (`≈ 7.63e-6`) of its original value. (Standard uniform-quantizer
+//! result; see e.g. the fixed-point quantization literature.)
+//!
+//! Rounding each component independently means the decoded values no longer sum
+//! to exactly one, so [`dequantize_dist`] **renormalizes** — rescaling the row
+//! back onto the simplex is the correct, proportion-preserving repair, and
+//! baking it into the decoder keeps every caller honest.
+//!
+//! This codec is for **strategy export only** — a lossy snapshot for a runtime
+//! that just reads the policy. It is *not* a solve checkpoint: quantizing raw
+//! regret/strategy accumulators would destroy the precision and reproducibility
+//! a resumed solve depends on, and a checkpoint would additionally need to
+//! record the algorithm and its per-row lane count. Because the codec consumes
+//! a finished distribution rather than algorithm-specific state, it is correct
+//! for every matcher by construction.
+
+/// A fixed-width unsigned code type for the unit-interval quantizer.
+///
+/// `MAX_CODE = 2^bits − 1` is the full-scale code that `1.0` maps to, so the
+/// quantum is `1 / MAX_CODE` and both `0.0` and `1.0` stay exactly
+/// representable.
+pub trait FixedWidth: Copy {
+    /// Largest code, representing `1.0` (i.e. `2^bits − 1`).
+    const MAX_CODE: u32;
+    /// Build the code type from a `u32` in `0..=MAX_CODE`.
+    fn from_code(code: u32) -> Self;
+    /// The numeric value of this code in `0..=MAX_CODE`.
+    fn code(self) -> u32;
+}
+
+impl FixedWidth for u8 {
+    const MAX_CODE: u32 = u8::MAX as u32;
+    fn from_code(code: u32) -> Self {
+        code as u8
+    }
+    fn code(self) -> u32 {
+        u32::from(self)
+    }
+}
+
+impl FixedWidth for u16 {
+    const MAX_CODE: u32 = u16::MAX as u32;
+    fn from_code(code: u32) -> Self {
+        code as u16
+    }
+    fn code(self) -> u32 {
+        u32::from(self)
+    }
+}
+
+impl FixedWidth for u32 {
+    const MAX_CODE: u32 = u32::MAX;
+    fn from_code(code: u32) -> Self {
+        code
+    }
+    fn code(self) -> u32 {
+        self
+    }
+}
+
+/// Encode a probability distribution to fixed-width codes.
+///
+/// Inputs are clamped to `[0, 1]` so an out-of-range component (e.g. a tiny
+/// negative from float error) can never wrap the integer cast.
+#[must_use]
+pub fn quantize_dist<Q: FixedWidth>(probs: &[f32]) -> Vec<Q> {
+    let scale = Q::MAX_CODE as f32;
+    probs
+        .iter()
+        .map(|&x| {
+            let clamped = x.clamp(0.0, 1.0);
+            // `round` gives nearest-integer (ties away from zero), the choice
+            // that halves the worst-case error versus truncation.
+            Q::from_code((clamped * scale).round() as u32)
+        })
+        .collect()
+}
+
+/// Decode fixed-width codes back to a probability distribution, renormalized to
+/// sum to one. An all-zero (or empty) input falls back to the uniform
+/// distribution, the only sensible distribution with no information.
+#[must_use]
+pub fn dequantize_dist<Q: FixedWidth>(codes: &[Q]) -> Vec<f32> {
+    let scale = Q::MAX_CODE as f32;
+    let mut out: Vec<f32> = codes.iter().map(|&c| c.code() as f32 / scale).collect();
+    crate::probability::normalize_inplace(&mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn u16_roundtrip_within_one_quantum() {
+        let probs = [0.1f32, 0.2, 0.3, 0.4];
+        let back = dequantize_dist::<u16>(&quantize_dist::<u16>(&probs));
+        for (a, b) in probs.iter().zip(&back) {
+            assert!((a - b).abs() < 1.0 / 65535.0 + 1e-7, "{a} vs {b}");
+        }
+        assert!((back.iter().sum::<f32>() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn one_hot_roundtrips() {
+        let back = dequantize_dist::<u16>(&quantize_dist::<u16>(&[0.0f32, 1.0, 0.0]));
+        assert!((back[1] - 1.0).abs() < 1e-6);
+        assert!(back[0].abs() < 1e-6 && back[2].abs() < 1e-6);
+    }
+
+    #[test]
+    fn all_zero_codes_decode_to_uniform() {
+        let back = dequantize_dist::<u16>(&[0u16, 0, 0, 0]);
+        assert!(back.iter().all(|&v| (v - 0.25).abs() < 1e-6));
+    }
+
+    #[test]
+    fn u8_and_u32_widths_supported() {
+        let probs = [0.25f32, 0.25, 0.5];
+        let b8 = dequantize_dist::<u8>(&quantize_dist::<u8>(&probs));
+        assert!((b8.iter().sum::<f32>() - 1.0).abs() < 1e-6);
+        let b32 = dequantize_dist::<u32>(&quantize_dist::<u32>(&probs));
+        for (a, b) in probs.iter().zip(&b32) {
+            assert!((a - b).abs() < 1e-6, "{a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn out_of_range_inputs_are_clamped() {
+        let codes = quantize_dist::<u16>(&[2.0, -1.0]);
+        assert_eq!(codes[0], 65535);
+        assert_eq!(codes[1], 0);
+    }
+}

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,0 +1,504 @@
+//! The concrete regret-update rules.
+//!
+//! Each type here is a zero-sized marker implementing [`UpdateRule`]; the
+//! algorithm lives entirely in its method bodies, which reproduce the exact
+//! floating-point arithmetic of the matching scalar matcher so a batched
+//! matcher at batch size 1 agrees bit-for-bit. The five rules span the shape
+//! space the abstraction must cover: signed vs. floored regret, weighted vs.
+//! discounted accumulation, and non-predictive (2 lanes) vs. predictive (3).
+//!
+//! Two recurring ideas, stated once:
+//!
+//! - **Discounting old regret.** Regret accumulated under early, poorly-informed
+//!   strategies is downweighted so the running totals track improving play. The
+//!   factor `d(t, e) = tᵉ / (tᵉ + 1)` rises toward 1 with `t`, so recent regret
+//!   is discounted less than old regret. (Brown & Sandholm 2019,
+//!   *Solving Imperfect-Information Games via Discounted Regret Minimization*,
+//!   arXiv:1809.04040.)
+//! - **Prediction.** If play changes smoothly, the next instantaneous regret
+//!   resembles the last one, so a predictive rule forms its strategy from the
+//!   cumulative regret *plus* that most-recent regret — reacting one step early.
+//!   The prediction is transient: it shapes the strategy but is never stored
+//!   into cumulative regret. (Farina, Kroer & Sandholm 2021, arXiv:2007.14358;
+//!   Xu et al. 2024, *Minimizing Weighted Counterfactual Regret with Optimistic
+//!   Online Mirror Descent*, arXiv:2404.13891.)
+
+use crate::discount::DiscountParams;
+use crate::probability::normalize_inplace;
+use crate::regret_minimizer::regret_match;
+use crate::update_rule::UpdateRule;
+
+/// Discount parameters for the `+`/predictive discounted rules: `alpha`
+/// discounts cumulative regret, `gamma` discounts the average-strategy
+/// contribution. (Unlike full DCFR there is no separate negative-regret
+/// exponent — flooring at zero removes negative regret outright.)
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PlusDiscount {
+    /// Regret-discount exponent.
+    pub alpha: f32,
+    /// Average-strategy-discount exponent.
+    pub gamma: f32,
+}
+
+/// `((t-1)/t)^gamma`, the average-strategy discount the `+` rules apply once
+/// they have a previous iterate. Returns `0.0` at `t == 1`, where there is no
+/// prior strategy to carry forward (matching the scalar matchers).
+fn plus_strategy_discount(t: usize, gamma: f32) -> f32 {
+    if t > 1 {
+        ((t - 1) as f32 / t as f32).powf(gamma)
+    } else {
+        0.0
+    }
+}
+
+/// Normalize `[regret · regret_discount + last_inst]^+` into `out`. With
+/// `regret_discount = 1` and zero prediction this reduces to plain regret
+/// matching, so it serves predictive and non-predictive derivation alike.
+fn predicted_strategy(regret: &[f32], last_inst: &[f32], regret_discount: f32, out: &mut [f32]) {
+    for ((o, &r), &m) in out.iter_mut().zip(regret).zip(last_inst) {
+        *o = (r * regret_discount + m).max(0.0);
+    }
+    normalize_inplace(out);
+}
+
+// ── DCFR ─────────────────────────────────────────────────────────────────────
+
+/// Discounted CFR. Signed cumulative regret, each iteration's old positive
+/// regret scaled by `d(t, α)` and old negative regret by `d(t, β)` before the
+/// new regret is added; the average strategy is discounted by `(t/(t+1))^γ`.
+pub struct Dcfr;
+
+/// Shared per-iteration factors for [`Dcfr`].
+pub struct DcfrStep {
+    positive: f32,
+    negative: f32,
+    strategy: f32,
+}
+
+impl UpdateRule for Dcfr {
+    type Params = DiscountParams;
+    type Step = DcfrStep;
+    const LANES: usize = 2;
+
+    fn step(p: &Self::Params, t: usize) -> Self::Step {
+        DcfrStep {
+            positive: DiscountParams::discount_factor(t, p.alpha),
+            negative: DiscountParams::discount_factor(t, p.beta),
+            strategy: (t as f32 / (t as f32 + 1.0)).powf(p.gamma),
+        }
+    }
+
+    fn strategy_from_lanes(_: &Self::Params, regret: &[f32], _: &[f32], _: f32, out: &mut [f32]) {
+        regret_match(regret, out);
+    }
+
+    fn pre_discount(_: &Self::Step) -> f32 {
+        0.0
+    }
+    fn post_discount(_: &Self::Step) -> f32 {
+        0.0
+    }
+
+    fn accumulate_regret(s: &Self::Step, old: f32, reward: f32, expected: f32) -> f32 {
+        let d = if old > 0.0 { s.positive } else { s.negative };
+        old * d + (reward - expected)
+    }
+
+    fn strategy_accumulation(s: &Self::Step) -> (f32, f32) {
+        (s.strategy, 1.0)
+    }
+
+    fn regret_weight_step(s: &Self::Step, old_w: f32) -> f32 {
+        old_w * s.positive + 1.0
+    }
+    fn regret_weight_total(_: &Self::Params, _t: usize, accum_w: f32) -> f32 {
+        accum_w
+    }
+}
+
+// ── DCFR+ ─────────────────────────────────────────────────────────────────────
+
+/// Discounted CFR+. Like DCFR but regret is floored at zero *after* the discount
+/// and add, so a recovering action need not first pay back accumulated negative
+/// regret. A single discount `d(t-1, α)` applies (no negative branch, since
+/// there is no negative regret to treat).
+pub struct DcfrPlus;
+
+/// Shared per-iteration factors for [`DcfrPlus`].
+pub struct PlusStep {
+    regret: f32,
+    strategy: f32,
+}
+
+impl DcfrPlus {
+    /// Grid-searched defaults from the source paper: `α = 1.5`, `γ = 4`.
+    pub const RECOMMENDED: PlusDiscount = PlusDiscount {
+        alpha: 1.5,
+        gamma: 4.0,
+    };
+}
+
+impl UpdateRule for DcfrPlus {
+    type Params = PlusDiscount;
+    type Step = PlusStep;
+    const LANES: usize = 2;
+
+    fn step(p: &Self::Params, t: usize) -> Self::Step {
+        PlusStep {
+            // The accumulator being discounted is the *previous* iterate, so its
+            // index is t-1; nothing to discount on the first iteration.
+            regret: if t > 1 {
+                DiscountParams::discount_factor(t - 1, p.alpha)
+            } else {
+                0.0
+            },
+            strategy: plus_strategy_discount(t, p.gamma),
+        }
+    }
+
+    fn strategy_from_lanes(_: &Self::Params, regret: &[f32], _: &[f32], _: f32, out: &mut [f32]) {
+        regret_match(regret, out);
+    }
+
+    fn pre_discount(_: &Self::Step) -> f32 {
+        0.0
+    }
+    fn post_discount(_: &Self::Step) -> f32 {
+        0.0
+    }
+
+    fn accumulate_regret(s: &Self::Step, old: f32, reward: f32, expected: f32) -> f32 {
+        // Left-associative `old*d + reward - expected`, mirroring dcfr_plus.rs.
+        (old * s.regret + reward - expected).max(0.0)
+    }
+
+    fn strategy_accumulation(s: &Self::Step) -> (f32, f32) {
+        (s.strategy, 1.0)
+    }
+
+    fn regret_weight_step(s: &Self::Step, old_w: f32) -> f32 {
+        old_w * s.regret + 1.0
+    }
+    fn regret_weight_total(_: &Self::Params, _t: usize, accum_w: f32) -> f32 {
+        accum_w
+    }
+}
+
+// ── Linear CFR ────────────────────────────────────────────────────────────────
+
+/// Linear CFR. The cheapest discounting: weight iteration `t`'s regret and
+/// strategy contribution by `t`, so early iterates fade linearly. Equivalent to
+/// DCFR with α=β=γ=1, but expressed (like the scalar) in the increasing-weight
+/// form, so the stored totals grow rather than staying bounded.
+pub struct LinearCfr;
+
+/// Shared per-iteration factor for [`LinearCfr`]: the iteration weight `t`.
+pub struct LinearStep {
+    t: f32,
+}
+
+impl UpdateRule for LinearCfr {
+    type Params = ();
+    type Step = LinearStep;
+    const LANES: usize = 2;
+
+    fn step(_: &Self::Params, t: usize) -> Self::Step {
+        LinearStep { t: t as f32 }
+    }
+
+    fn strategy_from_lanes(_: &Self::Params, regret: &[f32], _: &[f32], _: f32, out: &mut [f32]) {
+        regret_match(regret, out);
+    }
+
+    fn pre_discount(_: &Self::Step) -> f32 {
+        0.0
+    }
+    fn post_discount(_: &Self::Step) -> f32 {
+        0.0
+    }
+
+    fn accumulate_regret(s: &Self::Step, old: f32, reward: f32, expected: f32) -> f32 {
+        old + s.t * (reward - expected)
+    }
+
+    fn strategy_accumulation(s: &Self::Step) -> (f32, f32) {
+        (1.0, s.t)
+    }
+
+    fn regret_weight_step(_: &Self::Step, old_w: f32) -> f32 {
+        old_w // unused; the total is a closed form of t
+    }
+    fn regret_weight_total(_: &Self::Params, t: usize, _accum_w: f32) -> f32 {
+        // Σ_{i=1}^{t} i = t(t+1)/2, the total weight applied to regret.
+        let t = t as f32;
+        t * (t + 1.0) / 2.0
+    }
+}
+
+// ── PCFR+ ─────────────────────────────────────────────────────────────────────
+
+/// Predictive CFR+. CFR+'s floored regret, but the strategy is formed from the
+/// cumulative regret plus the most-recent instantaneous regret (the
+/// prediction), and the average strategy uses quadratic (`t²`) weighting.
+pub struct PcfrPlus;
+
+/// Shared per-iteration factor for [`PcfrPlus`]: the quadratic averaging weight
+/// `t²`.
+pub struct PcfrPlusStep {
+    quadratic: f32,
+}
+
+impl UpdateRule for PcfrPlus {
+    type Params = ();
+    type Step = PcfrPlusStep;
+    const LANES: usize = 3;
+
+    fn step(_: &Self::Params, t: usize) -> Self::Step {
+        PcfrPlusStep {
+            quadratic: (t * t) as f32,
+        }
+    }
+
+    fn strategy_from_lanes(
+        _: &Self::Params,
+        regret: &[f32],
+        last: &[f32],
+        d: f32,
+        out: &mut [f32],
+    ) {
+        predicted_strategy(regret, last, d, out);
+    }
+
+    fn pre_discount(_: &Self::Step) -> f32 {
+        1.0 // undiscounted prediction: regret enters the strategy at full weight
+    }
+    fn post_discount(_: &Self::Step) -> f32 {
+        1.0
+    }
+
+    fn accumulate_regret(_: &Self::Step, old: f32, reward: f32, expected: f32) -> f32 {
+        (old + (reward - expected)).max(0.0)
+    }
+
+    fn strategy_accumulation(s: &Self::Step) -> (f32, f32) {
+        (1.0, s.quadratic)
+    }
+
+    fn regret_weight_step(_: &Self::Step, old_w: f32) -> f32 {
+        old_w // unused; total is T
+    }
+    fn regret_weight_total(_: &Self::Params, t: usize, _accum_w: f32) -> f32 {
+        t as f32
+    }
+}
+
+// ── PDCFR+ ────────────────────────────────────────────────────────────────────
+
+/// Predictive Discounted CFR+. Stores regret like DCFR+ (discounted, floored)
+/// but forms the strategy like PCFR+ (regret plus prediction) — additionally
+/// discounting the regret term by `d(t, α)` inside the prediction. The widest
+/// shape: predictive (3 lanes) *and* discounted.
+pub struct PdcfrPlus;
+
+/// Shared per-iteration factors for [`PdcfrPlus`].
+pub struct PdcfrPlusStep {
+    /// `d(t-1, α)` — discount on the previous accumulator and the pre-update
+    /// strategy's regret term.
+    previous: f32,
+    /// `d(t, α)` — discount on the post-update strategy's regret term.
+    current: f32,
+    strategy: f32,
+}
+
+impl PdcfrPlus {
+    /// Grid-searched defaults from the source paper: `α = 2.3`, `γ = 5`.
+    pub const RECOMMENDED: PlusDiscount = PlusDiscount {
+        alpha: 2.3,
+        gamma: 5.0,
+    };
+}
+
+impl UpdateRule for PdcfrPlus {
+    type Params = PlusDiscount;
+    type Step = PdcfrPlusStep;
+    const LANES: usize = 3;
+
+    fn step(p: &Self::Params, t: usize) -> Self::Step {
+        PdcfrPlusStep {
+            previous: if t > 1 {
+                DiscountParams::discount_factor(t - 1, p.alpha)
+            } else {
+                0.0
+            },
+            current: DiscountParams::discount_factor(t, p.alpha),
+            strategy: plus_strategy_discount(t, p.gamma),
+        }
+    }
+
+    fn strategy_from_lanes(
+        _: &Self::Params,
+        regret: &[f32],
+        last: &[f32],
+        d: f32,
+        out: &mut [f32],
+    ) {
+        predicted_strategy(regret, last, d, out);
+    }
+
+    fn pre_discount(s: &Self::Step) -> f32 {
+        s.previous
+    }
+    fn post_discount(s: &Self::Step) -> f32 {
+        s.current
+    }
+
+    fn accumulate_regret(s: &Self::Step, old: f32, reward: f32, expected: f32) -> f32 {
+        // Parenthesized inst, mirroring pdcfr_plus.rs.
+        (old * s.previous + (reward - expected)).max(0.0)
+    }
+
+    fn strategy_accumulation(s: &Self::Step) -> (f32, f32) {
+        (s.strategy, 1.0)
+    }
+
+    fn regret_weight_step(s: &Self::Step, old_w: f32) -> f32 {
+        old_w * s.previous + 1.0
+    }
+    fn regret_weight_total(_: &Self::Params, _t: usize, accum_w: f32) -> f32 {
+        accum_w
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discount::DiscountParams;
+    use crate::update_rule::UpdateRule;
+
+    // ── DCFR (signed, non-predictive) ───────────────────────────────────────
+
+    #[test]
+    fn dcfr_mirrors_scalar() {
+        let p = DiscountParams::RECOMMENDED;
+        let s = Dcfr::step(&p, 3);
+        let pos = DiscountParams::discount_factor(3, p.alpha);
+        let neg = DiscountParams::discount_factor(3, p.beta);
+        let strat = (3.0f32 / 4.0).powf(p.gamma);
+
+        // Sign of the OLD regret picks the discount; instantaneous regret is
+        // added parenthesized, exactly as dcfr.rs writes it.
+        assert_eq!(
+            Dcfr::accumulate_regret(&s, 2.0, 5.0, 1.0),
+            2.0 * pos + (5.0 - 1.0)
+        );
+        assert_eq!(
+            Dcfr::accumulate_regret(&s, -2.0, 5.0, 1.0),
+            -2.0 * neg + (5.0 - 1.0)
+        );
+        assert_eq!(Dcfr::strategy_accumulation(&s), (strat, 1.0));
+        assert_eq!(Dcfr::regret_weight_step(&s, 4.0), 4.0 * pos + 1.0);
+        assert_eq!(Dcfr::regret_weight_total(&p, 7, 9.5), 9.5);
+        assert_eq!(Dcfr::pre_discount(&s), 0.0);
+        assert_eq!(Dcfr::LANES, 2);
+    }
+
+    // ── DCFR+ (floored, non-predictive) ─────────────────────────────────────
+
+    #[test]
+    fn dcfr_plus_mirrors_scalar() {
+        let p = DcfrPlus::RECOMMENDED;
+        let s = DcfrPlus::step(&p, 3);
+        let prev = DiscountParams::discount_factor(2, p.alpha);
+        let strat = (2.0f32 / 3.0).powf(p.gamma);
+
+        // Left-associative `old*prev + rw - exp`, floored — exactly dcfr_plus.rs.
+        assert_eq!(
+            DcfrPlus::accumulate_regret(&s, 2.0, 5.0, 1.0),
+            (2.0 * prev + 5.0 - 1.0).max(0.0)
+        );
+        assert_eq!(DcfrPlus::accumulate_regret(&s, -10.0, 0.0, 1.0), 0.0); // floored
+        assert_eq!(DcfrPlus::strategy_accumulation(&s), (strat, 1.0));
+        assert_eq!(DcfrPlus::regret_weight_step(&s, 4.0), 4.0 * prev + 1.0);
+        assert_eq!(DcfrPlus::pre_discount(&s), 0.0); // non-predictive
+        assert_eq!(DcfrPlus::LANES, 2);
+    }
+
+    #[test]
+    fn dcfr_plus_first_iteration_has_no_history() {
+        let s = DcfrPlus::step(&DcfrPlus::RECOMMENDED, 1);
+        // t == 1: nothing to discount yet, so old regret is dropped entirely.
+        assert_eq!(
+            DcfrPlus::accumulate_regret(&s, 9.0, 2.0, 0.5),
+            (2.0f32 - 0.5).max(0.0)
+        );
+        assert_eq!(DcfrPlus::strategy_accumulation(&s).0, 0.0);
+    }
+
+    // ── Linear CFR (weighted, non-predictive) ───────────────────────────────
+
+    #[test]
+    fn linear_cfr_mirrors_scalar() {
+        let s = LinearCfr::step(&(), 4);
+        // R += t * (rw - exp); X += t * x; weight total = t(t+1)/2.
+        assert_eq!(
+            LinearCfr::accumulate_regret(&s, 3.0, 5.0, 1.0),
+            3.0 + 4.0 * (5.0 - 1.0)
+        );
+        assert_eq!(LinearCfr::strategy_accumulation(&s), (1.0, 4.0));
+        assert_eq!(LinearCfr::regret_weight_total(&(), 4, 0.0), 4.0 * 5.0 / 2.0);
+        assert_eq!(LinearCfr::pre_discount(&s), 0.0);
+        assert_eq!(LinearCfr::LANES, 2);
+    }
+
+    // ── PCFR+ (predictive, no discount) ─────────────────────────────────────
+
+    #[test]
+    fn pcfr_plus_mirrors_scalar() {
+        let s = PcfrPlus::step(&(), 3);
+        // Floored CFR+ regret; quadratic averaging weight t².
+        assert_eq!(
+            PcfrPlus::accumulate_regret(&s, 1.0, 4.0, 1.0),
+            (1.0f32 + (4.0 - 1.0)).max(0.0)
+        );
+        assert_eq!(PcfrPlus::accumulate_regret(&s, 0.0, 0.0, 5.0), 0.0); // floored
+        assert_eq!(PcfrPlus::strategy_accumulation(&s), (1.0, 9.0)); // t² = 9
+        assert_eq!(PcfrPlus::regret_weight_total(&(), 3, 0.0), 3.0); // T
+        // Predictive but undiscounted: regret enters the strategy at weight 1.
+        assert_eq!(PcfrPlus::pre_discount(&s), 1.0);
+        assert_eq!(PcfrPlus::post_discount(&s), 1.0);
+        assert_eq!(PcfrPlus::LANES, 3);
+
+        // strategy = normalize([regret + last_inst]^+)
+        let mut out = [0.0f32; 2];
+        PcfrPlus::strategy_from_lanes(&(), &[1.0, 0.0], &[0.0, 1.0], 1.0, &mut out);
+        assert!((out[0] - 0.5).abs() < 1e-6 && (out[1] - 0.5).abs() < 1e-6);
+    }
+
+    // ── PDCFR+ (predictive, discounted; 3 lanes) ────────────────────────────
+
+    #[test]
+    fn pdcfr_plus_mirrors_scalar() {
+        let p = PdcfrPlus::RECOMMENDED; // alpha 2.3, gamma 5
+        let s = PdcfrPlus::step(&p, 3);
+        let prev = DiscountParams::discount_factor(2, p.alpha);
+        let curr = DiscountParams::discount_factor(3, p.alpha);
+        let strat = (2.0f32 / 3.0).powf(p.gamma);
+
+        // Stored regret: DCFR+-style with parenthesized inst, floored.
+        assert_eq!(
+            PdcfrPlus::accumulate_regret(&s, 2.0, 5.0, 1.0),
+            (2.0 * prev + (5.0 - 1.0)).max(0.0)
+        );
+        assert_eq!(PdcfrPlus::strategy_accumulation(&s), (strat, 1.0));
+        assert_eq!(PdcfrPlus::regret_weight_step(&s, 4.0), 4.0 * prev + 1.0);
+        // Pre-update strategy uses last iteration's discount d(t-1); post uses d(t).
+        assert_eq!(PdcfrPlus::pre_discount(&s), prev);
+        assert_eq!(PdcfrPlus::post_discount(&s), curr);
+        assert_eq!(PdcfrPlus::LANES, 3);
+
+        // strategy = normalize([regret*disc + last_inst]^+)
+        let mut out = [0.0f32; 2];
+        PdcfrPlus::strategy_from_lanes(&p, &[1.0, 1.0], &[0.0, 0.0], curr, &mut out);
+        assert!((out[0] - 0.5).abs() < 1e-6 && (out[1] - 0.5).abs() < 1e-6);
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,167 @@
+//! Pluggable accumulator storage.
+//!
+//! At scale the matchers *are* the memory of a solve, and how their cells are
+//! read and written decides whether many threads can cooperate. The storage
+//! layer therefore abstracts a single accumulator cell behind plain
+//! load/store, letting one update routine run unchanged over two backends:
+//!
+//! - [`Local`] — an ordinary `Cell`. No synchronization, no atomics. Because
+//!   `Cell` is `!Sync`, a `Local`-backed matcher cannot be shared across
+//!   threads, so single-threaded misuse is caught at compile time.
+//! - [`Atomic`] — an `AtomicU32` (the `f32` bit pattern) read and written with
+//!   `Relaxed` ordering, so updates can go through a shared `&self` from many
+//!   worker threads.
+//!
+//! **On the concurrent backend's correctness.** Updates are a non-atomic
+//! read-modify-write — load a cell, add, store — so two threads touching the
+//! same cell can lose one update. We tolerate this deliberately. There is *no*
+//! published theorem that CFR converges under racy accumulation; the
+//! justification is the Hogwild result (Recht et al. 2011), where lock-free
+//! stochastic-gradient updates converge *in expectation* under sparse,
+//! bounded-staleness contention, reinforced by CFR's demonstrated tolerance of
+//! the high-variance noise that Monte-Carlo CFR sampling injects. A lost update
+//! is a small, bounded perturbation. This is empirically-motivated robustness —
+//! strongest when threads touch mostly disjoint information sets — and is not a
+//! guarantee. Single-threaded `Local` runs are fully deterministic; use them
+//! when reproducibility matters.
+
+use std::cell::Cell;
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+/// One `f32` accumulator cell: relaxed load/store, zero-initialized.
+pub trait FloatCell: Default {
+    /// Read the current value.
+    fn load(&self) -> f32;
+    /// Overwrite the value.
+    fn store(&self, v: f32);
+}
+
+/// One iteration-counter cell: load and post-increment.
+pub trait CounterCell: Default {
+    /// Read the current count.
+    fn load(&self) -> usize;
+    /// Increment by one, returning the value *before* the increment.
+    fn fetch_incr(&self) -> usize;
+}
+
+/// A choice of cell types for a matcher's accumulators and iteration clock.
+pub trait StorageBackend {
+    /// Cell type for the per-action accumulators.
+    type Float: FloatCell;
+    /// Cell type for the shared iteration counter.
+    type Counter: CounterCell;
+}
+
+// ── Local: single-threaded, zero-overhead ───────────────────────────────────
+
+impl FloatCell for Cell<f32> {
+    fn load(&self) -> f32 {
+        self.get()
+    }
+    fn store(&self, v: f32) {
+        self.set(v);
+    }
+}
+
+impl CounterCell for Cell<usize> {
+    fn load(&self) -> usize {
+        self.get()
+    }
+    fn fetch_incr(&self) -> usize {
+        let prev = self.get();
+        self.set(prev + 1);
+        prev
+    }
+}
+
+/// Single-threaded backend. `Cell` is `!Sync`, so a matcher built on it is
+/// confined to one thread by the type system.
+pub struct Local;
+
+impl StorageBackend for Local {
+    type Float = Cell<f32>;
+    type Counter = Cell<usize>;
+}
+
+// ── Atomic: lock-free, Sync ──────────────────────────────────────────────────
+
+impl FloatCell for AtomicU32 {
+    fn load(&self) -> f32 {
+        // We store the raw bit pattern, not a numeric encoding, so `to_bits`/
+        // `from_bits` round-trips every value (including NaN and signed zero).
+        f32::from_bits(AtomicU32::load(self, Ordering::Relaxed))
+    }
+    fn store(&self, v: f32) {
+        AtomicU32::store(self, v.to_bits(), Ordering::Relaxed);
+    }
+}
+
+impl CounterCell for AtomicUsize {
+    fn load(&self) -> usize {
+        AtomicUsize::load(self, Ordering::Relaxed)
+    }
+    fn fetch_incr(&self) -> usize {
+        self.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+/// Lock-free backend. Cells are `Sync`, so the matcher can be updated through a
+/// shared reference from many threads (see the module note on benign races).
+pub struct Atomic;
+
+impl StorageBackend for Atomic {
+    type Float = AtomicU32;
+    type Counter = AtomicUsize;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn float_cell_roundtrips<C: FloatCell>() {
+        let c = C::default();
+        assert_eq!(c.load(), 0.0);
+        for &v in &[1.0f32, -2.5, 0.0, 1e9, -1e-9] {
+            c.store(v);
+            assert_eq!(c.load(), v, "round-trip {v}");
+        }
+    }
+
+    #[test]
+    fn local_float_cell_roundtrips() {
+        float_cell_roundtrips::<<Local as StorageBackend>::Float>();
+    }
+
+    #[test]
+    fn atomic_float_cell_roundtrips_via_bits() {
+        float_cell_roundtrips::<<Atomic as StorageBackend>::Float>();
+    }
+
+    fn counter_increments<C: CounterCell>() {
+        let c = C::default();
+        assert_eq!(c.load(), 0);
+        assert_eq!(c.fetch_incr(), 0); // returns previous
+        assert_eq!(c.fetch_incr(), 1);
+        assert_eq!(c.load(), 2);
+    }
+
+    #[test]
+    fn local_counter_increments() {
+        counter_increments::<<Local as StorageBackend>::Counter>();
+    }
+
+    #[test]
+    fn atomic_counter_increments() {
+        counter_increments::<<Atomic as StorageBackend>::Counter>();
+    }
+
+    #[test]
+    fn atomic_backend_cells_are_shareable() {
+        // A compile-time proof that the concurrent backend's cells can be
+        // shared across threads; the single-threaded `Local` cells cannot
+        // (Cell is !Sync), which is exactly the guard we want.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<<Atomic as StorageBackend>::Float>();
+        assert_send_sync::<<Atomic as StorageBackend>::Counter>();
+    }
+}

--- a/src/update_rule.rs
+++ b/src/update_rule.rs
@@ -1,0 +1,153 @@
+//! The algorithm abstraction shared by the batched matcher.
+//!
+//! Every regret-matching variant keeps, per information set, a few `f32` arrays
+//! of length `num_actions` — call each a *lane*. Lane 0 is the cumulative
+//! regret (how much, in hindsight, we wish we had played each action more);
+//! lane 1 is the cumulative strategy (the running sum of strategies actually
+//! played, whose normalization is the equilibrium-approximating average). A
+//! predictive variant adds a third lane: the most recent one-step regret,
+//! reused as a cheap prediction of the next one. The *number* of lanes is the
+//! only algorithm-specific fact the storage and batching layers ever need; this
+//! trait carries it as [`UpdateRule::LANES`].
+//!
+//! The trait separates work that depends only on the iteration count from work
+//! that depends on the rewards. Time-dependent factors — discount exponents
+//! raised to powers, ratios — are computed once per batch into a
+//! [`UpdateRule::Step`] and shared across every row, so a decision point owning
+//! hundreds of information sets pays for each transcendental once, not hundreds
+//! of times. Even the strategy derivation, which a predictive rule discounts by
+//! such a factor, receives it precomputed (see [`UpdateRule::pre_discount`] /
+//! [`UpdateRule::post_discount`]) rather than recomputing a `powf` per row. The
+//! reward-dependent arithmetic is expressed per cell so it runs unchanged over
+//! either storage backend.
+//!
+//! Sources for the per-rule arithmetic are cited on each implementation in
+//! `crate::rules`.
+
+/// An abstract regret-update rule.
+///
+/// Implementors supply only the algorithm-specific arithmetic; storage,
+/// batching, readout, and serialization are written against this trait and make
+/// no assumption about which algorithm is in use.
+pub trait UpdateRule {
+    /// Per-instance parameters (e.g. discount exponents). Held per matcher, never
+    /// global, so two matchers of the same rule with different parameters
+    /// coexist.
+    type Params: Clone;
+
+    /// Constants derived once per iteration from `(params, t)` and shared across
+    /// all rows of a batch. This is where the expensive `powf`/division results
+    /// live so they are computed once, not once per row.
+    type Step;
+
+    /// Number of per-row state lanes: 2 for non-predictive rules (regret,
+    /// cumulative strategy), 3 for predictive ones (plus last-instantaneous
+    /// regret in lane 2).
+    const LANES: usize;
+
+    /// Compute the shared per-iteration constants for iteration `t` (1-based).
+    fn step(params: &Self::Params, t: usize) -> Self::Step;
+
+    /// Write the strategy a row plays given its stored lanes, normalized to a
+    /// distribution. `regret_discount` is the precomputed factor a predictive
+    /// rule applies to its regret before adding the prediction in `last_inst`;
+    /// non-predictive rules ignore both. Re-deriving the strategy from the lanes
+    /// — rather than storing it — lets the matcher drop a whole per-row array at
+    /// no precision cost, and is how a batched matcher reproduces a scalar
+    /// matcher's carried strategy exactly.
+    fn strategy_from_lanes(
+        params: &Self::Params,
+        regret: &[f32],
+        last_inst: &[f32],
+        regret_discount: f32,
+        out: &mut [f32],
+    );
+
+    /// Regret discount for deriving the *pre-update* strategy of an iteration
+    /// (the strategy carried in from the previous step). `0.0` for
+    /// non-predictive rules, which ignore it.
+    fn pre_discount(step: &Self::Step) -> f32;
+
+    /// Regret discount for deriving the *post-update* strategy of an iteration
+    /// (the strategy this step will play and accumulate). `0.0` for
+    /// non-predictive rules.
+    fn post_discount(step: &Self::Step) -> f32;
+
+    /// New cumulative regret for one action from its old value, this action's
+    /// `reward`, and the strategy's `expected` value. The instantaneous regret
+    /// is `reward − expected`; rules take the two terms separately rather than
+    /// pre-combined so each can reproduce its scalar counterpart's exact
+    /// floating-point expression (the associativity of `… + reward − expected`
+    /// is load-bearing for bit-for-bit equivalence).
+    fn accumulate_regret(step: &Self::Step, old_regret: f32, reward: f32, expected: f32) -> f32;
+
+    /// How the cumulative-strategy lane advances: `X ← X · discount + weight · x`
+    /// for the returned `(discount, weight)`. This single shape covers
+    /// discounted accumulation (`(d, 1)`) and increasing-weight accumulation
+    /// (`(1, t)` or `(1, t²)`) alike.
+    fn strategy_accumulation(step: &Self::Step) -> (f32, f32);
+
+    /// Advance the shared regret-weight accumulator. Discounted rules mirror the
+    /// regret discount here (`W ← W · d + 1`); closed-form rules may treat it as
+    /// a plain counter, since [`UpdateRule::regret_weight_total`] ignores it.
+    fn regret_weight_step(step: &Self::Step, old_w: f32) -> f32;
+
+    /// The total regret weight after `t` updates — the denominator that turns
+    /// accumulated regret into a true time average for the convergence
+    /// diagnostic. Discounted rules return the accumulated `accum_w`;
+    /// closed-form rules return a function of `t` (e.g. `t(t+1)/2`).
+    fn regret_weight_total(params: &Self::Params, t: usize, accum_w: f32) -> f32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A minimal non-predictive rule used only to exercise the trait surface.
+    struct MockRule;
+    impl UpdateRule for MockRule {
+        type Params = ();
+        type Step = ();
+        const LANES: usize = 2;
+        fn step(_: &Self::Params, _t: usize) -> Self::Step {}
+        fn strategy_from_lanes(
+            _: &Self::Params,
+            regret: &[f32],
+            _last_inst: &[f32],
+            _regret_discount: f32,
+            out: &mut [f32],
+        ) {
+            crate::regret_minimizer::regret_match(regret, out);
+        }
+        fn pre_discount(_: &Self::Step) -> f32 {
+            0.0
+        }
+        fn post_discount(_: &Self::Step) -> f32 {
+            0.0
+        }
+        fn accumulate_regret(_: &Self::Step, old_r: f32, reward: f32, expected: f32) -> f32 {
+            old_r + (reward - expected)
+        }
+        fn strategy_accumulation(_: &Self::Step) -> (f32, f32) {
+            (1.0, 1.0)
+        }
+        fn regret_weight_step(_: &Self::Step, old_w: f32) -> f32 {
+            old_w + 1.0
+        }
+        fn regret_weight_total(_: &Self::Params, _t: usize, accum_w: f32) -> f32 {
+            accum_w
+        }
+    }
+
+    #[test]
+    fn strategy_from_zero_regret_is_uniform() {
+        let mut out = [0.0f32; 3];
+        MockRule::strategy_from_lanes(&(), &[0.0, 0.0, 0.0], &[0.0, 0.0, 0.0], 0.0, &mut out);
+        assert!(out.iter().all(|&v| (v - 1.0 / 3.0).abs() < 1e-6));
+    }
+
+    #[test]
+    fn non_predictive_is_two_lane() {
+        assert_eq!(MockRule::LANES, 2);
+    }
+}

--- a/tests/batched_integration.rs
+++ b/tests/batched_integration.rs
@@ -1,0 +1,144 @@
+//! Integration tests for the batched matcher: lock-free convergence parity and
+//! the strategy-export round trip, both exercised through the public API.
+
+use little_sorry::{
+    Atomic, BatchedMatcher, Dcfr, DcfrPlus, DiscountParams, LinearCfr, Local, PcfrPlus, PdcfrPlus,
+    PlusDiscount, UpdateRule, dequantize_dist, quantize_dist,
+};
+use std::sync::Arc;
+use std::thread;
+
+/// Rock-Paper-Scissors payoff: `reward[a] = Σ_b M[a][b] · opponent[b]`, where
+/// `M` is the zero-sum win/lose/draw matrix. In symmetric self-play the
+/// opponent is the matcher's own current strategy, and the unique equilibrium —
+/// the average strategy this drives toward — is uniform `[1/3, 1/3, 1/3]`.
+fn rps_reward(opponent: &[f32]) -> [f32; 3] {
+    const M: [[f32; 3]; 3] = [
+        [0.0, -1.0, 1.0], // rock
+        [1.0, 0.0, -1.0], // paper
+        [-1.0, 1.0, 0.0], // scissors
+    ];
+    let mut reward = [0.0f32; 3];
+    for (a, row) in M.iter().enumerate() {
+        reward[a] = row.iter().zip(opponent).map(|(&m, &p)| m * p).sum();
+    }
+    reward
+}
+
+/// Single-threaded RPS self-play to convergence, returning the average strategy.
+fn solve_rps_local<R: UpdateRule>(params: R::Params, iters: usize) -> Vec<f32> {
+    let m = BatchedMatcher::<R, Local>::new(1, 3, params);
+    let mut strategy = [0.0f32; 3];
+    for _ in 0..iters {
+        m.current_into(0, &mut strategy);
+        let reward = rps_reward(&strategy);
+        m.update_row(0, |a| reward[a]);
+    }
+    let mut average = vec![0.0f32; 3];
+    m.average_into(0, &mut average);
+    average
+}
+
+fn assert_near_uniform(strategy: &[f32], tolerance: f32) {
+    for (a, &p) in strategy.iter().enumerate() {
+        assert!(
+            (p - 1.0 / 3.0).abs() < tolerance,
+            "action {a}: {p} not within {tolerance} of 1/3 (strategy {strategy:?})"
+        );
+    }
+}
+
+#[test]
+fn lockfree_concurrent_solve_converges_like_single_threaded() {
+    // Single-threaded reference: deterministic, must reach the equilibrium.
+    let reference = solve_rps_local::<Dcfr>(DiscountParams::RECOMMENDED, 20_000);
+    assert_near_uniform(&reference, 0.02);
+
+    // Concurrent: several threads hammer one shared matcher through `&self`,
+    // racing on its cells. We assert convergence to the same equilibrium within
+    // tolerance — not bit-equality, which contention deliberately forgoes.
+    let matcher = Arc::new(BatchedMatcher::<Dcfr, Atomic>::new(
+        1,
+        3,
+        DiscountParams::RECOMMENDED,
+    ));
+    let threads: Vec<_> = (0..4)
+        .map(|_| {
+            let m = Arc::clone(&matcher);
+            thread::spawn(move || {
+                let mut strategy = [0.0f32; 3];
+                for _ in 0..50_000 {
+                    m.current_into(0, &mut strategy);
+                    let reward = rps_reward(&strategy);
+                    m.update_row(0, |a| reward[a]);
+                }
+            })
+        })
+        .collect();
+    for t in threads {
+        t.join().unwrap();
+    }
+
+    let mut concurrent = vec![0.0f32; 3];
+    matcher.average_into(0, &mut concurrent);
+    assert_near_uniform(&concurrent, 0.05);
+}
+
+#[test]
+fn strategy_export_round_trip_preserves_every_rule() {
+    // Each rule solves RPS, then its average strategy is exported to u16 and
+    // reloaded. Quantization must not meaningfully move the solution: every
+    // component stays within one quantum, and the reloaded policy is still the
+    // equilibrium. New rules join this table automatically.
+    let dcfr = solve_rps_local::<Dcfr>(DiscountParams::RECOMMENDED, 20_000);
+    let dcfr_plus = solve_rps_local::<DcfrPlus>(DcfrPlus::RECOMMENDED, 20_000);
+    let linear = solve_rps_local::<LinearCfr>((), 20_000);
+    let pcfr_plus = solve_rps_local::<PcfrPlus>((), 20_000);
+    let pdcfr_plus = solve_rps_local::<PdcfrPlus>(PdcfrPlus::RECOMMENDED, 20_000);
+
+    let table: [(&str, &[f32]); 5] = [
+        ("DCFR", &dcfr),
+        ("DCFR+", &dcfr_plus),
+        ("LinearCFR", &linear),
+        ("PCFR+", &pcfr_plus),
+        ("PDCFR+", &pdcfr_plus),
+    ];
+
+    let quantum = 1.0 / 65535.0;
+    for (name, average) in table {
+        assert_near_uniform(average, 0.05);
+        let reloaded = dequantize_dist::<u16>(&quantize_dist::<u16>(average));
+        for (a, (&before, &after)) in average.iter().zip(&reloaded).enumerate() {
+            assert!(
+                (before - after).abs() < quantum,
+                "{name} action {a}: {before} -> {after} exceeds one quantum"
+            );
+        }
+        assert!(
+            (reloaded.iter().sum::<f32>() - 1.0).abs() < 1e-6,
+            "{name}: reloaded strategy not normalized"
+        );
+    }
+}
+
+/// A second matcher of the same rule with different parameters must coexist in
+/// the same process — parameters are per instance, never global.
+#[test]
+fn matchers_of_one_rule_with_different_params_coexist() {
+    let aggressive = solve_rps_local::<DcfrPlus>(
+        PlusDiscount {
+            alpha: 2.0,
+            gamma: 6.0,
+        },
+        20_000,
+    );
+    let gentle = solve_rps_local::<DcfrPlus>(
+        PlusDiscount {
+            alpha: 1.0,
+            gamma: 2.0,
+        },
+        20_000,
+    );
+    assert_near_uniform(&aggressive, 0.05);
+    assert_near_uniform(&gentle, 0.05);
+}


### PR DESCRIPTION
Summary:
- BatchedMatcher<Rule, Backend> drives many regret-matching cells over one
  shared iteration clock, amortizing the discount-factor transcendentals
  (powf/division) across a whole batch instead of recomputing them per row.
- UpdateRule trait separates time-dependent (Step/tick) from reward-dependent
  arithmetic; implemented by Dcfr, DcfrPlus, LinearCfr, PcfrPlus, PdcfrPlus,
  each reproducing its scalar twin's exact float arithmetic. Adds the
  PlusDiscount (alpha, gamma) parameter type for the + family.
- Pluggable storage backends: Local (Cell, !Sync) for single-threaded use and
  Atomic (AtomicU32, Hogwild-style lock-free, Relaxed) for concurrent solves,
  selected by type and enforced through Sync bounds with no unsafe.
- Dependency-free fixed-point strategy export codec (quantize) over u8/u16/u32,
  renormalizing to the simplex on decode via the shared probability kernel.
- Public re-exports, a crate-level batched-matcher example, README section, and
  the design spec / implementation plan under docs/specs, plus the branch review
  under docs/reviews.

Test Plan:
- mise check: fmt, clippy -D warnings, 106 nextest tests, 3 doctests, taplo lint
- Golden bit-for-bit parity: BatchedMatcher<R, Local> at batch-size-1 vs each
  scalar matcher, to_bits()-exact over 200 iterations
- Concurrent convergence + strategy-export round-trip integration tests
