### PR TITLE
perf: allocation-free BatchedMatcher hot paths + per-row rounding hash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ mise run check:clippy       # Check for lints (all features enabled)
 mise run check:test:nextest # Run tests with nextest
 mise run check:test:docs    # Test documentation examples
 mise run check:taplo:lint   # Lint TOML files
+mise run check:bench        # Build + smoke-run benches (criterion --test mode)
 
 # Fix issues
 mise fix                    # Run all fixers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ required-features = ["rps"]
 name = "cfr_hot_path"
 harness = false
 
+[[bench]]
+name = "batched_hot_path"
+harness = false
+
 [[test]]
 name = "convergence"
 required-features = ["rps"]

--- a/benches/batched_hot_path.rs
+++ b/benches/batched_hot_path.rs
@@ -5,7 +5,7 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use little_sorry::{Atomic, BatchedMatcher, Dcfr, DiscountParams, HalfStrategyShared};
+use little_sorry::{Atomic, BatchedMatcher, Dcfr, DiscountParams, HalfStrategyShared, Scratch};
 
 const NUM_ROWS: usize = 169;
 const NUM_ACTIONS: usize = 3;
@@ -32,6 +32,18 @@ fn bench_update_batch(c: &mut Criterion) {
     });
 }
 
+fn bench_update_batch_with(c: &mut Criterion) {
+    let m = new_matcher();
+    let mut scratch = Scratch::new(NUM_ACTIONS);
+    let mut expected = vec![0.0f32; NUM_ROWS];
+    c.bench_function("batched_update_batch_with_169x3", |b| {
+        b.iter(|| {
+            m.update_batch_with(&mut scratch, reward, &mut expected);
+            black_box(expected[0])
+        });
+    });
+}
+
 fn bench_current_into(c: &mut Criterion) {
     let m = new_matcher();
     let mut expected = vec![0.0f32; NUM_ROWS];
@@ -49,5 +61,10 @@ fn bench_current_into(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_update_batch, bench_current_into);
+criterion_group!(
+    benches,
+    bench_update_batch,
+    bench_update_batch_with,
+    bench_current_into
+);
 criterion_main!(benches);

--- a/benches/batched_hot_path.rs
+++ b/benches/batched_hot_path.rs
@@ -1,0 +1,53 @@
+//! Hot-path bench at the downstream consumer profile: one preflop decision
+//! node — 169 hand-class rows × 3 actions, DCFR (α=3, β=0, γ=20), lock-free
+//! `Atomic` cells, `HalfStrategyShared` layout.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use little_sorry::{Atomic, BatchedMatcher, Dcfr, DiscountParams, HalfStrategyShared};
+
+const NUM_ROWS: usize = 169;
+const NUM_ACTIONS: usize = 3;
+
+type Matcher = BatchedMatcher<Dcfr, Atomic, HalfStrategyShared>;
+
+fn new_matcher() -> Matcher {
+    Matcher::new(NUM_ROWS, NUM_ACTIONS, DiscountParams::new(3.0, 0.0, 20.0))
+}
+
+/// Fixed, cheap, row-varying reward so rows do not collapse to one strategy.
+fn reward(action: usize, row: usize) -> f32 {
+    [1.0f32, -0.5, 0.25][action] * (1.0 + (row % 13) as f32 * 0.05)
+}
+
+fn bench_update_batch(c: &mut Criterion) {
+    let m = new_matcher();
+    let mut expected = vec![0.0f32; NUM_ROWS];
+    c.bench_function("batched_update_batch_169x3", |b| {
+        b.iter(|| {
+            m.update_batch(reward, &mut expected);
+            black_box(expected[0])
+        });
+    });
+}
+
+fn bench_current_into(c: &mut Criterion) {
+    let m = new_matcher();
+    let mut expected = vec![0.0f32; NUM_ROWS];
+    for _ in 0..100 {
+        m.update_batch(reward, &mut expected);
+    }
+    let mut out = [0.0f32; NUM_ACTIONS];
+    let mut row = 0;
+    c.bench_function("batched_current_into_169x3", |b| {
+        b.iter(|| {
+            row = (row + 1) % NUM_ROWS;
+            m.current_into(row, &mut out);
+            black_box(out[0])
+        });
+    });
+}
+
+criterion_group!(benches, bench_update_batch, bench_current_into);
+criterion_main!(benches);

--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,10 @@ run = 'cargo nextest run --all-features --workspace --examples --bins --lib'
 description = "Test code examples in documentation"
 run = 'cargo test --doc --all-features --workspace'
 
+[tasks.'check:bench']
+description = "Build benches and smoke-run them once (criterion --test mode)"
+run = 'cargo bench --all-features -- --test'
+
 [tasks.'check:taplo:lint']
 description = "Check TOML files formatting"
 run = 'taplo lint $(git ls-files "*.toml")'

--- a/src/batched_matcher.rs
+++ b/src/batched_matcher.rs
@@ -59,6 +59,33 @@ impl Scratch {
     }
 }
 
+/// Actions covered by the stack-allocated row buffer; larger rows fall back
+/// to the heap. Downstream consumers run ≤ 4 actions.
+const INLINE_ACTIONS: usize = 8;
+
+/// A row-sized f32 buffer: inline array up to [`INLINE_ACTIONS`], heap `Vec`
+/// beyond, so read paths stay allocation-free at practical action counts.
+enum RowBuf {
+    Inline([f32; INLINE_ACTIONS]),
+    Heap(Vec<f32>),
+}
+
+impl RowBuf {
+    fn new(len: usize) -> Self {
+        if len <= INLINE_ACTIONS {
+            RowBuf::Inline([0.0; INLINE_ACTIONS])
+        } else {
+            RowBuf::Heap(vec![0.0; len])
+        }
+    }
+    fn slice_mut(&mut self, len: usize) -> &mut [f32] {
+        match self {
+            RowBuf::Inline(a) => &mut a[..len],
+            RowBuf::Heap(v) => &mut v[..len],
+        }
+    }
+}
+
 /// A batched regret matcher generic over the update rule `R`, the storage
 /// backend `B`, and the memory layout `L` (which lane stores hold cumulative
 /// regret and cumulative strategy). `L` defaults to [`F32Full`], reproducing
@@ -337,22 +364,29 @@ impl<R: UpdateRule, B: StorageBackend, L: Layout<R, B>> BatchedMatcher<R, B, L> 
     pub fn current_into(&self, row: usize, out: &mut [f32]) {
         assert!(row < self.num_rows, "row out of range");
         assert!(out.len() >= self.num_actions, "out too short");
-        let out = &mut out[..self.num_actions];
+        let n = self.num_actions;
+        let out = &mut out[..n];
         let t = self.num_updates();
         let step = R::step(&self.params, t);
         let predictive = R::LANES > 2;
-        let mut regret = vec![0.0; self.num_actions];
-        let mut last_inst = vec![0.0; self.num_actions];
-        self.regret.read_row(row, self.num_actions, &mut regret);
-        if predictive {
-            for (i, slot) in last_inst.iter_mut().enumerate() {
-                *slot = self.li_load(row * self.num_actions + i);
-            }
+
+        let mut regret_buf = RowBuf::new(n);
+        let regret = regret_buf.slice_mut(n);
+        self.regret.read_row(row, n, regret);
+
+        // 2-lane rules never read the last-instantaneous lane; hand them an
+        // empty slice instead of materializing a dead buffer.
+        let last_n = if predictive { n } else { 0 };
+        let mut last_buf = RowBuf::new(last_n);
+        let last_inst = last_buf.slice_mut(last_n);
+        for (i, slot) in last_inst.iter_mut().enumerate() {
+            *slot = self.li_load(row * n + i);
         }
+
         R::strategy_from_lanes(
             &self.params,
-            &regret,
-            &last_inst,
+            regret,
+            last_inst,
             R::post_discount(&step),
             out,
         );
@@ -913,11 +947,16 @@ mod alloc_tests {
         );
         let mut scratch = Scratch::new(4);
         let mut expected = vec![0.0f32; 169];
+        let mut out = [0.0f32; 3];
         // Warm-up outside the counted section.
         m.update_batch_with(&mut scratch, |a, _| [1.0, -0.5, 0.25][a], &mut expected);
+        m.current_into(0, &mut out);
         let n = allocations_in(|| {
             for _ in 0..10 {
                 m.update_batch_with(&mut scratch, |a, _| [1.0, -0.5, 0.25][a], &mut expected);
+                for row in 0..169 {
+                    m.current_into(row, &mut out);
+                }
             }
         });
         assert_eq!(n, 0, "hot path performed {n} heap allocations");

--- a/src/batched_matcher.rs
+++ b/src/batched_matcher.rs
@@ -28,10 +28,12 @@ use crate::storage::{AccumCell, CounterCell, StorageBackend};
 use crate::update_rule::UpdateRule;
 use std::marker::PhantomData;
 
-/// Per-call working buffers, sized to one row. Allocated once per update call
-/// and reused across every row in a batch, so the per-row hot path allocates
-/// nothing.
-struct Scratch {
+/// Reusable working buffers for one row's update. Constructed once (e.g. one
+/// per worker thread) and reused across calls via
+/// [`BatchedMatcher::update_batch_with`], so the per-visit hot path performs
+/// no heap allocation. A scratch built for `num_actions` serves any matcher
+/// with that many actions or fewer.
+pub struct Scratch {
     regret: Vec<f32>,
     last_inst: Vec<f32>,
     strategy: Vec<f32>,
@@ -39,13 +41,21 @@ struct Scratch {
 }
 
 impl Scratch {
-    fn new(num_actions: usize) -> Self {
+    /// Buffers sized for matchers with up to `num_actions` actions.
+    #[must_use]
+    pub fn new(num_actions: usize) -> Self {
         Self {
             regret: vec![0.0; num_actions],
             last_inst: vec![0.0; num_actions],
             strategy: vec![0.0; num_actions],
             reward: vec![0.0; num_actions],
         }
+    }
+
+    /// The action capacity this scratch was built for.
+    #[must_use]
+    pub fn num_actions(&self) -> usize {
+        self.regret.len()
     }
 }
 
@@ -162,8 +172,10 @@ impl<R: UpdateRule, B: StorageBackend, L: Layout<R, B>> BatchedMatcher<R, B, L> 
         let predictive = R::LANES > 2;
 
         // Snapshot the lanes we read, and cache the rewards so the value
-        // accessor is called exactly once per action.
-        self.regret.read_row(row, a, &mut s.regret);
+        // accessor is called exactly once per action. The scratch may be
+        // over-sized (built for a wider matcher), so every buffer is sliced
+        // to this matcher's action count.
+        self.regret.read_row(row, a, &mut s.regret[..a]);
         for i in 0..a {
             if predictive {
                 s.last_inst[i] = self.li_load(row * a + i);
@@ -176,12 +188,12 @@ impl<R: UpdateRule, B: StorageBackend, L: Layout<R, B>> BatchedMatcher<R, B, L> 
         // regret term by the previous iterate's factor).
         R::strategy_from_lanes(
             &self.params,
-            &s.regret,
-            &s.last_inst,
+            &s.regret[..a],
+            &s.last_inst[..a],
             R::pre_discount(step),
-            &mut s.strategy,
+            &mut s.strategy[..a],
         );
-        let expected = crate::vector_ops::dot(&s.strategy, &s.reward);
+        let expected = crate::vector_ops::dot(&s.strategy[..a], &s.reward[..a]);
 
         // Per-cell regret update; predictive rules also store the fresh
         // instantaneous regret for next tick's prediction.
@@ -193,19 +205,19 @@ impl<R: UpdateRule, B: StorageBackend, L: Layout<R, B>> BatchedMatcher<R, B, L> 
                 s.last_inst[i] = inst;
             }
         }
-        self.regret.write_row(row, a, &s.regret);
+        self.regret.write_row(row, a, &s.regret[..a]);
 
         // The strategy this tick plays (and accumulates) is derived from the
         // updated lanes, then folded into the cumulative-strategy lane.
         R::strategy_from_lanes(
             &self.params,
-            &s.regret,
-            &s.last_inst,
+            &s.regret[..a],
+            &s.last_inst[..a],
             R::post_discount(step),
-            &mut s.strategy,
+            &mut s.strategy[..a],
         );
         self.strategy
-            .accumulate(row, a, step, &s.strategy, self.num_updates());
+            .accumulate(row, a, step, &s.strategy[..a], self.num_updates());
 
         expected
     }
@@ -219,14 +231,34 @@ impl<R: UpdateRule, B: StorageBackend, L: Layout<R, B>> BatchedMatcher<R, B, L> 
     ///
     /// Panics if `expected_out.len() < num_rows`.
     pub fn update_batch(&self, value: impl Fn(usize, usize) -> f32, expected_out: &mut [f32]) {
+        self.update_batch_with(&mut Scratch::new(self.num_actions), value, expected_out);
+    }
+
+    /// [`update_batch`](Self::update_batch) with caller-owned scratch buffers —
+    /// the allocation-free hot path. Keep one [`Scratch`] per worker thread and
+    /// reuse it across calls and matchers.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `expected_out.len() < num_rows` or
+    /// `scratch.num_actions() < num_actions`.
+    pub fn update_batch_with(
+        &self,
+        scratch: &mut Scratch,
+        value: impl Fn(usize, usize) -> f32,
+        expected_out: &mut [f32],
+    ) {
         assert!(
             expected_out.len() >= self.num_rows,
             "expected_out too short"
         );
+        assert!(
+            scratch.num_actions() >= self.num_actions,
+            "scratch too small"
+        );
         let step = self.tick();
-        let mut scratch = Scratch::new(self.num_actions);
         for (row, ev) in expected_out.iter_mut().enumerate().take(self.num_rows) {
-            *ev = self.update_one(row, &step, |a| value(a, row), &mut scratch);
+            *ev = self.update_one(row, &step, |a| value(a, row), scratch);
         }
         self.advance_weight(&step);
     }
@@ -239,10 +271,28 @@ impl<R: UpdateRule, B: StorageBackend, L: Layout<R, B>> BatchedMatcher<R, B, L> 
     ///
     /// Panics if `row >= num_rows`.
     pub fn update_row(&self, row: usize, value: impl Fn(usize) -> f32) -> f32 {
+        self.update_row_with(&mut Scratch::new(self.num_actions), row, value)
+    }
+
+    /// [`update_row`](Self::update_row) with caller-owned scratch buffers — the
+    /// allocation-free single-row path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `row >= num_rows` or `scratch.num_actions() < num_actions`.
+    pub fn update_row_with(
+        &self,
+        scratch: &mut Scratch,
+        row: usize,
+        value: impl Fn(usize) -> f32,
+    ) -> f32 {
         assert!(row < self.num_rows, "row out of range");
+        assert!(
+            scratch.num_actions() >= self.num_actions,
+            "scratch too small"
+        );
         let step = self.tick();
-        let mut scratch = Scratch::new(self.num_actions);
-        let ev = self.update_one(row, &step, value, &mut scratch);
+        let ev = self.update_one(row, &step, value, scratch);
         self.advance_weight(&step);
         ev
     }
@@ -727,5 +777,149 @@ mod tests {
         let m = BatchedMatcher::<Dcfr, Local>::new(1, 3, DiscountParams::RECOMMENDED);
         let mut out = [0.0f32; 2];
         m.regret_into(0, &mut out);
+    }
+
+    #[test]
+    fn update_batch_with_matches_update_batch_bit_for_bit() {
+        // Twin matchers over an identical deterministic reward stream; one uses
+        // the allocating entry point, the other a reused, over-sized scratch.
+        let params = DiscountParams::RECOMMENDED;
+        let a = BatchedMatcher::<Dcfr, Local>::new(3, 3, params);
+        let b = BatchedMatcher::<Dcfr, Local>::new(3, 3, params);
+        let mut scratch = Scratch::new(5); // over-sized on purpose
+        let mut ev_a = [0.0f32; 3];
+        let mut ev_b = [0.0f32; 3];
+        let mut state = 0x9876_5432_10ab_cdefu64;
+        for _ in 0..100 {
+            let rewards: Vec<f32> = (0..9).map(|_| next_reward(&mut state)).collect();
+            a.update_batch(|act, row| rewards[row * 3 + act], &mut ev_a);
+            b.update_batch_with(&mut scratch, |act, row| rewards[row * 3 + act], &mut ev_b);
+            for (x, y) in ev_a.iter().zip(&ev_b) {
+                assert_eq!(x.to_bits(), y.to_bits(), "expected values diverged");
+            }
+            for row in 0..3 {
+                assert_bits("regret", &b.raw_regret(row), &a.raw_regret(row));
+                assert_bits("strategy", &b.raw_strategy(row), &a.raw_strategy(row));
+            }
+        }
+    }
+
+    #[test]
+    fn update_row_with_matches_update_row_bit_for_bit() {
+        let params = DiscountParams::RECOMMENDED;
+        let a = BatchedMatcher::<Dcfr, Local>::new(1, 3, params);
+        let b = BatchedMatcher::<Dcfr, Local>::new(1, 3, params);
+        let mut scratch = Scratch::new(3);
+        let mut state = 0x0f0f_1234_dead_beefu64;
+        for _ in 0..100 {
+            let rewards: Vec<f32> = (0..3).map(|_| next_reward(&mut state)).collect();
+            let ev_a = a.update_row(0, |act| rewards[act]);
+            let ev_b = b.update_row_with(&mut scratch, 0, |act| rewards[act]);
+            assert_eq!(ev_a.to_bits(), ev_b.to_bits(), "expected values diverged");
+            assert_bits("regret", &b.raw_regret(0), &a.raw_regret(0));
+            assert_bits("strategy", &b.raw_strategy(0), &a.raw_strategy(0));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "scratch too small")]
+    fn update_batch_with_panics_on_small_scratch() {
+        let m = BatchedMatcher::<Dcfr, Local>::new(1, 3, DiscountParams::RECOMMENDED);
+        let mut scratch = Scratch::new(2);
+        let mut ev = [0.0f32; 1];
+        m.update_batch_with(&mut scratch, |a, _| a as f32, &mut ev);
+    }
+}
+
+/// Thread-filtered allocation counting: the global allocator counts only
+/// while the current thread has opted in, so unrelated tests running in the
+/// same process (plain `cargo test`) cannot perturb the count.
+#[cfg(test)]
+mod alloc_tests {
+    use super::*;
+    use crate::discount::DiscountParams;
+    use crate::lane::HalfStrategyShared;
+    use crate::rules::Dcfr;
+    use crate::storage::Atomic;
+    use std::alloc::{GlobalAlloc, Layout as AllocLayout, System};
+    use std::cell::Cell;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+    thread_local! {
+        // const-initialized TLS: no lazy allocation inside the allocator.
+        static COUNTING: Cell<bool> = const { Cell::new(false) };
+    }
+
+    struct CountingAlloc;
+
+    fn note_alloc() {
+        // try_with: TLS may be unavailable during thread teardown.
+        let _ = COUNTING.try_with(|c| {
+            if c.get() {
+                ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+    }
+
+    unsafe impl GlobalAlloc for CountingAlloc {
+        unsafe fn alloc(&self, l: AllocLayout) -> *mut u8 {
+            note_alloc();
+            unsafe { System.alloc(l) }
+        }
+        unsafe fn alloc_zeroed(&self, l: AllocLayout) -> *mut u8 {
+            note_alloc();
+            unsafe { System.alloc_zeroed(l) }
+        }
+        unsafe fn realloc(&self, p: *mut u8, l: AllocLayout, n: usize) -> *mut u8 {
+            note_alloc();
+            unsafe { System.realloc(p, l, n) }
+        }
+        unsafe fn dealloc(&self, p: *mut u8, l: AllocLayout) {
+            unsafe { System.dealloc(p, l) }
+        }
+    }
+
+    #[global_allocator]
+    static COUNTING_ALLOC: CountingAlloc = CountingAlloc;
+
+    fn allocations_in(f: impl FnOnce()) -> usize {
+        COUNTING.with(|c| c.set(true));
+        let before = ALLOC_COUNT.load(Ordering::Relaxed);
+        f();
+        let after = ALLOC_COUNT.load(Ordering::Relaxed);
+        COUNTING.with(|c| c.set(false));
+        after - before
+    }
+
+    #[test]
+    fn counting_harness_detects_allocations() {
+        // Negative control: a plain Vec allocation must register, otherwise
+        // the zero-alloc assertion below would pass vacuously.
+        let n = allocations_in(|| {
+            let v = vec![0u8; 128];
+            std::hint::black_box(&v);
+        });
+        assert!(n > 0, "counting allocator failed to observe an allocation");
+    }
+
+    #[test]
+    fn hot_path_is_allocation_free() {
+        // The exact consumer profile: Dcfr, Atomic, HalfStrategyShared.
+        let m = BatchedMatcher::<Dcfr, Atomic, HalfStrategyShared>::new(
+            169,
+            3,
+            DiscountParams::new(3.0, 0.0, 20.0),
+        );
+        let mut scratch = Scratch::new(4);
+        let mut expected = vec![0.0f32; 169];
+        // Warm-up outside the counted section.
+        m.update_batch_with(&mut scratch, |a, _| [1.0, -0.5, 0.25][a], &mut expected);
+        let n = allocations_in(|| {
+            for _ in 0..10 {
+                m.update_batch_with(&mut scratch, |a, _| [1.0, -0.5, 0.25][a], &mut expected);
+            }
+        });
+        assert_eq!(n, 0, "hot path performed {n} heap allocations");
     }
 }

--- a/src/lane.rs
+++ b/src/lane.rs
@@ -177,9 +177,11 @@ impl<B: StorageBackend> F32SumStrategy<B> {
 /// `sum_p/Σsum_p` recurrence: `W ← discount·W + weight`,
 /// `σ̄ += (weight/W)·(σ − σ̄)`. Always in [0,1] (convex), so u16 fixed-point is
 /// safe. `average_into` returns σ̄ directly (one normalize repairs rounding drift).
-/// Encoding uses **stochastic rounding** keyed by `(row, action, update_count)`,
-/// so sub-quantum increments survive in expectation and the average does not
-/// freeze under high-γ long-horizon DCFR (see `unit_fixed::encode_stochastic`).
+/// Encoding uses **stochastic rounding** keyed by `(row, update_count)` — one
+/// hash per row per tick yields an independent 16-bit draw per action (see
+/// `unit_fixed::RowDraws`) — so sub-quantum increments survive in expectation
+/// and the average does not freeze under high-γ long-horizon DCFR (see
+/// `unit_fixed::encode_stochastic`).
 pub struct U16AvgStrategy<B: StorageBackend> {
     cells: Vec<B::Cell<u16>>,
     weight: Vec<B::Cell<u32>>, // per-row W, f32 bits
@@ -239,12 +241,12 @@ impl<R: UpdateRule, B: StorageBackend> StrategyLane<R, B> for U16AvgStrategy<B> 
         let w_new = discount * self.w_load(row) + weight;
         self.w_store(row, w_new);
         let frac = if w_new > 0.0 { weight / w_new } else { 0.0 };
+        let mut draws = crate::unit_fixed::RowDraws::new(row, update_count);
         for (i, &s) in strategy[..n].iter().enumerate() {
             let idx = row * n + i;
             let cur = self.sigma(idx);
             let v = cur + frac * (s - cur);
-            let u = crate::unit_fixed::u01(row, i, update_count);
-            self.set_sigma_stochastic(idx, v, u);
+            self.set_sigma_stochastic(idx, v, draws.next_u01());
         }
     }
 
@@ -376,12 +378,12 @@ impl<R: UpdateRule, B: StorageBackend> StrategyLane<R, B> for U16AvgStrategyShar
         }
         let w = self.w_load();
         let frac = if w > 0.0 { weight / w } else { 0.0 };
+        let mut draws = crate::unit_fixed::RowDraws::new(row, update_count);
         for (i, &s) in strategy[..n].iter().enumerate() {
             let idx = row * n + i;
             let cur = self.sigma(idx);
             let v = cur + frac * (s - cur);
-            let u = crate::unit_fixed::u01(row, i, update_count);
-            self.set_sigma_stochastic(idx, v, u);
+            self.set_sigma_stochastic(idx, v, draws.next_u01());
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub use pdcfr_plus::PdcfrPlusRegretMatcher;
 pub use regret_minimizer::RegretMinimizer;
 
 // Batched, storage-generic machinery.
-pub use batched_matcher::BatchedMatcher;
+pub use batched_matcher::{BatchedMatcher, Scratch};
 // Memory layout types.
 pub use lane::{
     F32Full, F32Regret, F32SumStrategy, HalfBoth, HalfBothShared, HalfRegret, HalfStrategy,

--- a/src/unit_fixed.rs
+++ b/src/unit_fixed.rs
@@ -15,25 +15,58 @@ pub(crate) fn decode(code: u32, max_code: u32) -> f32 {
     code as f32 / max_code as f32
 }
 
-/// Deterministic, stateless draw in `[0, 1)` from a cell+tick key. Same key ⇒
-/// same value; no shared mutable state, so it is reproducible and race-free
-/// under the `Atomic` backend. The three key components are mixed into one word
-/// and run through the splitmix64 finalizer; the top 24 bits become the fraction
-/// (24 bits is exactly representable in an `f32` mantissa, so the division is
-/// exact and unbiased).
+/// Splitmix64-finalized hash of a `(row, update_count, chunk)` key — the same
+/// key-mix the old per-cell hash used, with the 4-action chunk index in the
+/// per-action slot. One output word carries four independent 16-bit draws.
 #[inline]
-pub(crate) fn u01(row: usize, action: usize, update_count: usize) -> f32 {
+fn row_bits(row: usize, update_count: usize, chunk: usize) -> u64 {
     let mut z = (row as u64)
         .wrapping_mul(0x9E37_79B9_7F4A_7C15)
-        .wrapping_add((action as u64).wrapping_mul(0xC2B2_AE3D_27D4_EB4F))
+        .wrapping_add((chunk as u64).wrapping_mul(0xC2B2_AE3D_27D4_EB4F))
         .wrapping_add((update_count as u64).wrapping_mul(0x1656_67B1_9E37_79F9));
     z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
     z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-    z ^= z >> 31;
-    // Top 24 bits → [0, 1).
-    #[allow(clippy::cast_precision_loss)]
-    let num = (z >> 40) as f32;
-    num / ((1u32 << 24) as f32)
+    z ^ (z >> 31)
+}
+
+/// Deterministic, stateless per-row draw stream for stochastic rounding: one
+/// [`row_bits`] hash yields draws for four actions (16 bits each — exactly
+/// the u16 lane quantum), so a row of ≤ 4 actions costs one hash per tick
+/// where a per-cell hash would cost one per action. Same key ⇒ same stream;
+/// no shared mutable state, so it is reproducible and race-free under the
+/// `Atomic` backend. `bits / 2^16` is exact in f32, so draws are unbiased on
+/// the 2⁻¹⁶ grid.
+pub(crate) struct RowDraws {
+    row: usize,
+    update_count: usize,
+    bits: u64,
+    action: usize,
+}
+
+impl RowDraws {
+    #[inline]
+    pub(crate) fn new(row: usize, update_count: usize) -> Self {
+        Self {
+            row,
+            update_count,
+            bits: row_bits(row, update_count, 0),
+            action: 0,
+        }
+    }
+
+    /// The draw for the next action of this row/tick, in `[0, 1)`.
+    #[inline]
+    pub(crate) fn next_u01(&mut self) -> f32 {
+        let (chunk, slot) = (self.action / 4, self.action % 4);
+        if self.action > 0 && slot == 0 {
+            self.bits = row_bits(self.row, self.update_count, chunk);
+        }
+        self.action += 1;
+        // Truncating to the slot's low 16 bits is the point of the shift.
+        #[allow(clippy::cast_possible_truncation)]
+        let bits16 = (self.bits >> (16 * slot)) as u16;
+        f32::from(bits16) / 65_536.0
+    }
 }
 
 /// Stochastic-rounding encode of `x ∈ [0,1]` to a code in `0..=max_code`, using a
@@ -78,19 +111,83 @@ mod tests {
     }
 
     #[test]
-    fn u01_is_deterministic_and_in_range() {
-        // Same key ⇒ identical bits; draws stay in [0, 1).
-        for &(r, a, t) in &[(0usize, 0usize, 1usize), (3, 1, 999), (7, 2, 67_000)] {
-            assert_eq!(u01(r, a, t).to_bits(), u01(r, a, t).to_bits());
-        }
-        for t in 0..10_000usize {
-            let u = u01(t % 5, t % 3, t);
-            assert!((0.0..1.0).contains(&u), "u01 out of range: {u}");
+    fn row_draws_deterministic_and_in_range() {
+        for &(r, t) in &[(0usize, 1usize), (3, 999), (168, 67_000)] {
+            let mut a = RowDraws::new(r, t);
+            let mut b = RowDraws::new(r, t);
+            for _ in 0..8 {
+                // 8 draws crosses a chunk boundary (two hashes).
+                let (x, y) = (a.next_u01(), b.next_u01());
+                assert_eq!(x.to_bits(), y.to_bits(), "same key ⇒ same stream");
+                assert!((0.0..1.0).contains(&x), "draw out of range: {x}");
+            }
         }
         // Distinct keys generally differ (guards against a constant generator).
-        assert_ne!(u01(0, 0, 1), u01(0, 0, 2));
-        assert_ne!(u01(0, 0, 1), u01(1, 0, 1));
-        assert_ne!(u01(0, 0, 1), u01(0, 1, 1));
+        assert_ne!(
+            RowDraws::new(0, 1).next_u01(),
+            RowDraws::new(0, 2).next_u01()
+        );
+        assert_ne!(
+            RowDraws::new(0, 1).next_u01(),
+            RowDraws::new(1, 1).next_u01()
+        );
+    }
+
+    #[test]
+    fn row_draws_are_unbiased_per_action() {
+        // E[encode_stochastic] must recover a sub-quantum value for EVERY
+        // action slot of the row hash, not just slot 0.
+        let max = u16::MAX as u32;
+        let x = 0.001_530_5_f32;
+        let scaled = f64::from(x.clamp(0.0, 1.0) * max as f32);
+        let n = 200_000u32;
+        for action in 0..4usize {
+            let mut sum = 0u64;
+            for t in 0..n {
+                let mut draws = RowDraws::new(7, t as usize);
+                let mut u = draws.next_u01();
+                for _ in 0..action {
+                    u = draws.next_u01();
+                }
+                sum += u64::from(encode_stochastic(x, max, u));
+            }
+            let mean = sum as f64 / f64::from(n);
+            assert!(
+                (mean - scaled).abs() < 0.05,
+                "action {action} biased: mean {mean} vs true {scaled}"
+            );
+        }
+    }
+
+    #[test]
+    fn row_draws_are_independent_across_actions() {
+        // Draws for different actions of one row come from disjoint 16-bit
+        // slices; empirically the joint sub-median event must hit ~1/4.
+        let n = 100_000usize;
+        let mut below = [0u32; 4];
+        let mut joint = [[0u32; 4]; 4];
+        for t in 0..n {
+            let mut draws = RowDraws::new(3, t);
+            let u: Vec<f32> = (0..4).map(|_| draws.next_u01()).collect();
+            for a in 0..4 {
+                if u[a] < 0.5 {
+                    below[a] += 1;
+                }
+                for b in (a + 1)..4 {
+                    if u[a] < 0.5 && u[b] < 0.5 {
+                        joint[a][b] += 1;
+                    }
+                }
+            }
+        }
+        for a in 0..4 {
+            let p = f64::from(below[a]) / n as f64;
+            assert!((p - 0.5).abs() < 0.01, "action {a} marginal {p}");
+            for b in (a + 1)..4 {
+                let p = f64::from(joint[a][b]) / n as f64;
+                assert!((p - 0.25).abs() < 0.01, "pair ({a},{b}) joint {p}");
+            }
+        }
     }
 
     #[test]
@@ -131,7 +228,7 @@ mod tests {
         let n = 200_000u32;
         let mut sum = 0u64;
         for t in 0..n {
-            let u = u01(7, 2, t as usize);
+            let u = RowDraws::new(7, t as usize).next_u01();
             sum += u64::from(encode_stochastic(x, max, u));
         }
         let mean = sum as f64 / f64::from(n);


### PR DESCRIPTION
## Changes

- **CR1** — `Scratch` is now public and caller-owned; new additive `update_batch_with` / `update_row_with` take `&mut Scratch` so the update hot path performs **zero heap allocations** (one scratch per worker thread, reused across calls and matchers — a scratch built for N actions serves any matcher with ≤ N actions). Old entry points delegate unchanged.
- **CR2** — `current_into` uses an inline stack buffer (heap fallback only above 8 actions) and skips materializing the `last_inst` buffer entirely for 2-lane rules (DCFR et al.), which never read it.
- **CR3** — the u16 strategy lanes' stochastic rounding now hashes **once per (row, tick, 4-action chunk)** instead of once per cell, slicing 16 bits per action from one splitmix64 output (16 bits = exactly the u16 lane quantum). ~3× fewer hashes at 3 actions.
- **CR4** — new `benches/batched_hot_path.rs` at the exact consumer profile (169 rows × 3 actions, `Dcfr(3.0, 0.0, 20.0)`, `Atomic`, `HalfStrategyShared`), plus a `check:bench` mise task so every bench builds and smoke-runs (criterion `--test` mode) in CI. Previously no bench target was compiled in CI at all.

## Before/after (same bench code, single-threaded criterion, local dev box)

| bench | 4.0.0 baseline | after CR1–CR3 | delta |
|---|---|---|---|
| `batched_update_batch_169x3` | 4.533 µs | 4.474 µs | −1.3% |
| `batched_update_batch_with_169x3` (new hot path) | — | 4.420 µs | −2.5% vs baseline `update_batch` |
| `batched_current_into_169x3` | 27.16 ns | 4.08 ns | **−85%** |

`update_batch` is dominated by the 169×3 relaxed-atomic cell traffic, so scratch reuse + fewer hashes are a few percent single-threaded; `current_into` was dominated by its two mallocs. The allocation removal also takes malloc out of the 15-thread Hogwild picture entirely (allocator lock traffic isn't captured by this bench).

## Acceptance mapping

- **CR1/CR2 bit-identity**: the existing golden bit-tests (batch-size-1 vs scalar matchers, 200-step fixed reward stream, raw-bit compare of regret/strategy/current/average) pin the math; a new twin test drives `update_batch` vs `update_batch_with` (with a deliberately over-sized, reused scratch) and asserts bit-equality of all state. `vector_ops::dot`'s sequential add order is untouched.
- **Zero allocations**: a thread-filtered counting `#[global_allocator]` test harness (with a negative-control test) proves `update_batch_with` + `current_into` do 0 heap allocations over 10 batch ticks × 169 rows at the consumer profile. Runs in CI via the normal nextest `--lib` pass.
- **CR3 (not bit-identical, as accepted)**: new tests show the per-action draws are unbiased (E[encode] recovers a sub-quantum value for every action slot) and independent across actions of a row (marginals ≈ 0.5, pairwise joints ≈ 0.25 over 100k ticks); the >1M-update γ=10 freeze-regression test still tracks f32.